### PR TITLE
docs: update Docker image reference to `xrserver-all`

### DIFF
--- a/samples/doc-store
+++ b/samples/doc-store
@@ -5,7 +5,7 @@
 # https://github.com/xregistry/server/releases/tag/dev
 
 # Start a new xRegistry server, if you don't have one already running
-docker run --name xreg -dti -p 8080:8080 ghcr.io/xregistry/xreg-server-all
+docker run --name xreg -dti -p 8080:8080 ghcr.io/xregistry/xrserver-all
 
 # Point to this server
 XR_SERVER=localhost:8080

--- a/samples/endpoints
+++ b/samples/endpoints
@@ -5,7 +5,7 @@
 # https://github.com/xregistry/server/releases/tag/dev
 
 # Start a new xRegistry server, if you don't have one already running
-docker run --name xreg -dti -p 8080:8080 ghcr.io/xregistry/xreg-server-all
+docker run --name xreg -dti -p 8080:8080 ghcr.io/xregistry/xrserver-all
 
 # Point to this server
 XR_SERVER=localhost:8080


### PR DESCRIPTION
## Summary

Updates the Docker image reference to use the current image name.

### Changes

Replaced:
```sh
docker run --name xreg -dti -p 8080:8080 ghcr.io/xregistry/xreg-server-all
```

With:

```sh
docker run --name xreg -dti -p 8080:8080 ghcr.io/xregistry/xrserver-all
```