### PR TITLE
PR code cleanup

### DIFF
--- a/registry/db.go
+++ b/registry/db.go
@@ -158,25 +158,6 @@ type Tx struct {
 	// Resources (keyed by DbSID) that need Resource.ValidateResource()
 	// (re-)run before this Tx's results are visible - including their
 	// default-version-copy cascade and xref fan-out.
-	// Entity.VersionMetaPostSave()/SyncSystemProp()/SaveSystemProps() mark a
-	// Resource here (see AddResourceToValidate()) instead of running
-	// the (potentially expensive) validation immediately every time a
-	// Version/Meta belonging to it is saved - which used to happen
-	// redundantly, e.g. once for the $TBD ancestorid placeholder save
-	// and again when it's resolved (see plan.md "Backend / SQL
-	// re-architecture" item (b)). The few explicit call sites that
-	// need r's post-validation state right away (e.g.
-	// Resource.GetDefault() shortly after an Upsert) still call
-	// r.ValidateResource() directly/synchronously instead of deferring
-	// via this mechanism - see ValidateResource()'s own doc comment for
-	// why it clears any pending mark for itself at the very start, so a
-	// direct/synchronous call never gets redundantly re-run by the
-	// drain below. Registry.Validate() drains this, running
-	// ValidateResource() AT MOST ONCE per Resource per Tx, using the
-	// final state - mirroring how GroupsToValidate (above) already
-	// works. This is Tx-scoped bookkeeping (hence living here), even
-	// though the actual draining logic lives on Registry - see
-	// Registry.Validate().
 	ResourcesToValidate map[string]*resourceValidation
 
 	// Snapshot of the batch Registry.Validate()'s drain loop is

--- a/registry/entity.go
+++ b/registry/entity.go
@@ -2887,8 +2887,8 @@ func (e *Entity) ValidateMap(mapAttr *Attribute, val any, path *PropPath) *XRErr
 		Item:       mapAttr.Item.Item,
 		Attributes: mapAttr.Item.Attributes,
 		Enum:       mapAttr.Enum,
-		Strict:    mapAttr.Strict,
-		MatchCase: mapAttr.MatchCase,
+		Strict:     mapAttr.Strict,
+		MatchCase:  mapAttr.MatchCase,
 	}
 
 	for _, k := range valValue.MapKeys() {
@@ -2951,8 +2951,8 @@ func (e *Entity) ValidateArray(arrayAttr *Attribute, val any, path *PropPath) *X
 		Item:       arrayAttr.Item.Item,
 		Attributes: arrayAttr.Item.Attributes,
 		Enum:       arrayAttr.Enum,
-		Strict:    arrayAttr.Strict,
-		MatchCase: arrayAttr.MatchCase,
+		Strict:     arrayAttr.Strict,
+		MatchCase:  arrayAttr.MatchCase,
 	}
 
 	for i := 0; i < valValue.Len(); i++ {

--- a/registry/entity.go
+++ b/registry/entity.go
@@ -917,19 +917,6 @@ func (e *Entity) ClearResourceSystemDBProperty(pps ...*PropPath) {
 	}
 }
 
-func (e *Entity) ClearEntitySystemDBProperties() *XRError {
-	log.VPrintf(3, ">Enter: ClearEntitySystemDBProperties")
-	defer log.VPrintf(3, "<Exit ClearEntitySystemDBProperties")
-
-	Do(e.tx, `DELETE FROM Props
-              WHERE RegSID=? AND eSID=? AND IsSystemProp=true`,
-		e.Registry.DbSID, e.DbSID)
-
-	e.ResyncOwnProps()
-
-	return nil
-}
-
 // SetSystemDBProperty buffers a system-prop change into e.NewSystem -
 // it does NOT write to the DB immediately. The actual write (and, if
 // e is a Version, at most one re-run of the default-version cascade)
@@ -2351,7 +2338,15 @@ func (e *Entity) Save() *XRError {
 	}
 	e.NewObject = nil
 
-	e.VersionMetaPostSave()
+	// Make sure the Resource is validated when Version or Meta is changed.
+	if e.Type == ENTITY_VERSION {
+		// onlyMetaChanged=false because we need the full validation code.
+		v := e.Self.(*Version)
+		e.tx.AddResourceToValidate(v.Resource, false, false)
+	} else if e.Type == ENTITY_META {
+		meta := e.Self.(*Meta)
+		e.tx.AddResourceToValidate(meta.Resource, true, false)
+	}
 
 	return nil
 }
@@ -3484,31 +3479,14 @@ func (e *Entity) CalcAttrEnum(attr *Attribute, path *PropPath) ([]any, bool) {
 	return attr.Enum, isStrict
 }
 
-// This stuff implements the incremental population of the
-// Props/Entities tables described in sql.md. These tables
-// are now the sole, authoritative store for entity properties (own,
-// system, calculated, and cascaded/copied) - the old FullTree/Entities
-// views and Props table are no longer read from or written to anywhere
-// in the codebase (phase 2 of the sql.md migration). Every entity-
-// creation site (Registry/Group/Resource/Meta/Version) calls
-// EntityInsert() alongside its "real" table INSERT. Plain user-set
-// properties are written directly by Entity.SetDBProperty() (called
-// per-property during Save()'s NewObject traversal) and system-managed
-// ones by Entity.SetSystemDBProperty()/SyncSystemProp(); VersionMetaPostSave(),
-// called once at the very end of Save(), only needs to (re)compute
-// this entity's calculated singleton attributes (xid, isdefault,
-// RESOURCEid) and run whichever cascades are relevant given the
-// entity's type (default-version-copy, xref prop/version-copy).
-
 // EntityInsert adds a row to Entities for a newly-created
 // Registry/Group/Resource/Meta/Version - called from the same places
 // that insert into the corresponding "real" entity table, right after
 // e's fields (DbSID, ParentSID, etc.) have been populated. It also
 // writes e's write-once calculated ("IsCalcStatic") attributes here,
 // since they're provably immutable for the rest of this entity's
-// lifetime (see SaveCalcStaticInsert()'s doc comment) - so unlike
-// VersionMetaPostSave(), which runs on every Save(), this only ever runs once,
-// at creation.
+// lifetime (see SaveCalcStaticInsert()'s doc comment), this only ever runs
+// once, at creation.
 func (e *Entity) EntityInsert() {
 	defer log.Trace("EntityInsert", e.XID)()
 
@@ -3535,14 +3513,7 @@ func (e *Entity) EntityInsert() {
 // (propValue==nil) removes the row; otherwise it's REPLACEd with the
 // new value. isSystem marks whether this is a plain user-set prop
 // (SetDBProperty, false) or a system-managed one (SetSystemDBProperty,
-// true). Never touches cascaded (IsDefaultVerCopy/IsXrefPropCopy/
-// IsXrefVerCopy) or calculated (IsCalcStatic/IsCalcDynamic - see
-// SaveCalcStaticInsert()/SaveVersionCalc()) rows - those are
-// always written by their own dedicated code paths, never through
-// here. Versions.AncestorID/CreatedAt and Metas.xRefPath/defaultVID are
-// kept in sync by the FullTreeAncestor/FullTreeXref DB triggers
-// (init.sql) whenever the corresponding own row is written/removed
-// here.
+// true).
 func (e *Entity) DBWriteProp(name string, propValue *string,
 	propType string, docView bool, isSystem bool) {
 
@@ -3670,41 +3641,9 @@ func (e *Entity) DBDeletePropsBatch(names []string) {
 // DBWriteOwnProp writes (or deletes, if propValue is nil) a
 // plain user-set own property row for e - called by
 // Entity.SetDBProperty() as part of Save()'s per-property traversal.
-// Unlike SyncSystemProp, this never re-runs any cascade: Save()
-// already calls VersionMetaPostSave() once at the very end of the same Save()
-// call, which handles whatever cascade is relevant, so re-running it
-// here for every single property would be redundant, wasted work.
 func (e *Entity) DBWriteOwnProp(name string, propValue *string,
 	propType string, docView bool) {
 	e.DBWriteProp(name, propValue, propType, docView, false)
-}
-
-// SyncSystemProp keeps a single own (non-cascaded) Props row
-// in sync for a SYSTEM property that's written OUTSIDE of the normal
-// Save()/VersionMetaPostSave() flow. As of the System/NewSystem buffering split,
-// SetSystemDBProperty() no longer calls this directly (it buffers into
-// NewSystem instead - see SaveSystemProps()); this is kept as a small,
-// still-useful primitive for writing/deleting a single system-prop row
-// plus its cascade in one call, in case some future caller needs an
-// immediate (non-buffered) write.
-func (e *Entity) SyncSystemProp(name string, propValue *string,
-	propType string, docView bool) {
-
-	defer log.Trace("FullTree", "%s/%s", e.XID, name)()
-
-	e.DBWriteProp(name, propValue, propType, docView, true)
-
-	// If this is a Version, this prop change may also need to be
-	// reflected in the owning Resource's IsDefaultVerCopy set (if this
-	// Version happens to be the current default) - mark it for
-	// deferred (re-)validation (see Tx.AddResourceToValidate()) rather
-	// than running it immediately, since Save()'s own VersionMetaPostSave() already
-	// marked it once and this out-of-band write can just piggyback on
-	// that same deferred run.
-	if e.Type == ENTITY_VERSION {
-		v := e.Self.(*Version)
-		e.tx.AddResourceToValidate(v.Resource, true, false)
-	}
 }
 
 // SaveSystemProps flushes any system-prop changes buffered by
@@ -3712,13 +3651,7 @@ func (e *Entity) SyncSystemProp(name string, propValue *string,
 // called once per cached entity at Tx-commit time (see
 // tx.WriteCache()) and is a no-op if nothing was buffered. It diffs
 // NewSystem against System so only props that actually changed get
-// written to the DB, and - unlike SyncSystemProp()'s old behavior of
-// re-running the default-version cascade on every single system-prop
-// write - runs that cascade AT MOST ONCE per flush, no matter how many
-// system props changed on this entity since the last flush. Deletes
-// and inserts are each batched into (at most, if chunked) one
-// statement via DBDeletePropsBatch()/DBWritePropsBatch(),
-// instead of one round trip per changed prop.
+// written to the DB.
 func (e *Entity) SaveSystemProps() {
 	if e.NewSystem == nil {
 		return
@@ -3794,69 +3727,11 @@ func (e *Entity) SaveSystemProps() {
 	e.DBDeletePropsBatch(deleteNames)
 	e.DBWritePropsBatch(insertRows, true)
 
-	// Same idea as SyncSystemProp(): if e is a Version, mark the
-	// owning Resource for deferred (re-)validation
-	// (Tx.AddResourceToValidate()) so the Resource's mirrored props get
-	// refreshed once, no matter how many system props changed on this
-	// entity since the last flush.
+	// If this is a Version, make sure we fully validate its owning Resource
 	if e.Type == ENTITY_VERSION {
 		if v, ok := e.Self.(*Version); ok {
 			e.tx.AddResourceToValidate(v.Resource, true, false)
 		}
-	}
-}
-
-// VersionMetaPostSave is called at the very end of Entity.Save(). Save()'s own
-// property traversal already wrote this entity's own (non-cascaded,
-// non-calculated) rows directly into Props via SetDBProperty()/
-// DBWriteOwnProp() as it walked NewObject, so VersionMetaPostSave() itself
-// only needs to (re)compute whichever of this entity's calculated
-// singleton attributes can actually change post-creation (just a
-// Version's own isdefault - see SaveVersionCalc()'s doc comment;
-// xid/Resource.isdefault/Version.RESOURCEid are write-once, handled by
-// EntityInsert()/SaveCalcStaticInsert() instead) and mark the
-// owning Resource for deferred (re-)validation - see
-// Tx.AddResourceToValidate()'s doc comment for why this is deferred
-// rather than run immediately here.
-//
-// SaveXrefCascade() (ENTITY_META) used to run eagerly right here,
-// but that's wrong: Resource.UpsertMeta()'s xref-setting path (registry/
-// resource.go) calls Version.JustDelete() in a loop to remove this
-// Resource's own real Versions BEFORE it's done processing, and
-// JustDelete() itself can trigger a Meta save (via Resource.Touch())
-// partway through that loop - i.e. while some of this Resource's own
-// real Version rows still exist in Props. Running the xref
-// cascade eagerly at that point built synthetic xref-version-copy rows
-// whose Path collided with those still-present real rows (same
-// PropName, same Path, different eSID - a Props PRIMARY KEY
-// violation). Deferring it via AddResourceToValidate()/
-// Resource.ValidateResource() instead means it only actually runs once,
-// at Registry.Validate() time (called from Tx.Validate()), which is
-// always after all of this Resource's own Version deletes for the
-// current request have completed.
-//
-// This relies on EntityInsert() having already been called (every
-// entity-creation site does so unconditionally alongside its "real"
-// table INSERT - see EntityInsert's doc comment), so there's no
-// need to re-verify the Entities row exists here.
-func (e *Entity) VersionMetaPostSave() {
-	defer log.Trace("FullTree", "%s", e.XID)()
-
-	switch e.Type {
-	case ENTITY_VERSION:
-		e.SaveVersionCalc()
-		v := e.Self.(*Version)
-		// onlyMetaChanged=false: this fires for ANY Version save,
-		// including real content/ancestor changes (e.g. WillDelete()'s
-		// ancestorid relinking), which need the full CheckAncestors()/
-		// EnsureMaxVersions()/etc. checks - not just the meta-only
-		// subset - before EnsureLatest() can correctly determine the
-		// new "newest" Version.
-		e.tx.AddResourceToValidate(v.Resource, false, false)
-
-	case ENTITY_META:
-		meta := e.Self.(*Meta)
-		e.tx.AddResourceToValidate(meta.Resource, true, false)
 	}
 }
 
@@ -3865,15 +3740,21 @@ func (e *Entity) VersionMetaPostSave() {
 // pointing at the owning Resource's UID). Neither can ever change
 // after creation: an entity's UID/Path is immutable (no rename API -
 // reusing an existing ID just errors instead of renaming), and a
-// Version's owning Resource never changes. So, unlike the genuinely-
-// dynamic Version.isdefault (see SaveVersionCalc()) or a Resource's
-// own isdefault (simply mirrored in from its default Version by
-// SaveDefaultVersionCascade(), same as createdat/modifiedat - not a
-// calculated singleton at all), these only need to be computed once -
-// here, called from EntityInsert() right after creation - and are
-// never touched again by VersionMetaPostSave(). Marked IsCalcStatic=true
-// so later reads/cascades can identify them and, e.g., exclude them
-// when copying an entity's "real" props elsewhere.
+// Version's owning Resource never changes. So these only need to be
+// computed once - here, called from EntityInsert() right after
+// creation.
+// Marked IsCalcStatic=true so later reads/cascades can identify them
+// and, e.g., exclude them when copying an entity's "real" props
+// elsewhere.
+//
+// Also gives a brand-new Version its very first isdefault row (via
+// SaveVersionCalc() - see its doc comment): unlike xid/RESOURCEid,
+// isdefault's VALUE can change post-creation, but nothing else ever
+// INSERTs its row (the end-of-tx SaveDefaultVersionCascade() bulk
+// fix-up is an UPDATE...JOIN, so it can only correct an existing row,
+// never create one) - so without this, a new Version would have no
+// isdefault attribute at all until something else happened to trigger
+// a recompute.
 func (e *Entity) SaveCalcStaticInsert() {
 	defer log.Trace("FullTree", e.Path)()
 
@@ -3913,27 +3794,16 @@ func (e *Entity) SaveCalcStaticInsert() {
 			e.Registry.DbSID, e.Type, e.Plural, e.Singular, parentArg,
 			e.DbSID, e.UID, e.Path, "id"+string(DB_IN), e.Abstract,
 			e.ParentSID)
-	}
-}
 
-// ResyncOwnProps re-derives e's calculated Props rows
-// that can actually change post-creation. Used by code that clears
-// system props directly, outside of Save()/VersionMetaPostSave() (e.g.
-// ClearResourceSystemDBProperty, ClearEntitySystemDBProperties). e is
-// assumed to already have gone through at least one EntityInsert()
-// (so its write-once xid/isdefault/RESOURCEid rows already exist and
-// never need re-deriving here). If e is a Version, re-adds its
-// calculated (dynamic) isdefault row, and refreshes the owning
-// Resource's IsDefaultVerCopy set in case this Version is the current
-// default (Save()'s own cascade already ran before this out-of-band
-// write happened, so it won't run again).
-func (e *Entity) ResyncOwnProps() {
-	defer log.Trace("FullTree", e.XID)()
-
-	if e.Type == ENTITY_VERSION {
+		// Give this brand-new Version its first isdefault row. Its
+		// DELETE is a no-op here (nothing exists yet for this eSID),
+		// so this just inserts the initial value based on the owning
+		// Resource's Meta.defaultVID at this moment - which is fine
+		// even if it's not yet the final answer, since
+		// SaveDefaultVersionCascade() will fix it up (for every
+		// Version of this Resource) once EnsureLatest() has settled
+		// on the true default, at end-of-tx.
 		e.SaveVersionCalc()
-		v := e.Self.(*Version)
-		e.tx.AddResourceToValidate(v.Resource, true, false)
 	}
 }
 
@@ -3941,21 +3811,15 @@ func (e *Entity) ResyncOwnProps() {
 // for a (real, non-xref-synthetic) Version - the only Version-level
 // calculated value that can actually change post-creation (xid and
 // RESOURCEid are write-once - see SaveCalcStaticInsert(), called
-// once from EntityInsert() instead). e is always the real,
-// in-memory Entity (never just a SID/raw row) - either the one Save()
-// is currently running for, or the one ResyncOwnProps() is
-// resyncing out-of-band.
+// once from EntityInsert() instead). Unlike those, isdefault isn't
+// recomputed on every subsequent Save() either: its row is inserted
+// exactly once, from SaveCalcStaticInsert() at creation, and its
+// VALUE is thereafter only ever corrected in bulk, for every Version
+// of a Resource at once, by the end-of-tx SaveDefaultVersionCascade()
+// UPDATE. This func itself is only ever called from
+// SaveCalcStaticInsert(), for that one initial insert.
 func (e *Entity) SaveVersionCalc() {
 	defer log.Trace("FullTree", e.Path)()
-
-	// Own scoped delete (rather than relying on some shared blanket
-	// delete having already run) since this is the only calculated
-	// value left that needs recomputing on every relevant Save(). At
-	// most 1 IsCalcDynamic row ever exists per Version (the isdefault
-	// row inserted below); 0 if this is the first time this func runs
-	// for this Version.
-	DoZeroOne(e.tx, `DELETE FROM Props WHERE eSID=? AND IsCalcDynamic=true`,
-		e.DbSID)
 
 	// isdefault - true only if this Version is the owning Resource's
 	// current default (via its Meta.defaultVID), or - for a Resource
@@ -3987,7 +3851,7 @@ func (e *Entity) SaveVersionCalc() {
 // for a source Meta entity (e) whose xref may have just been set,
 // changed, or cleared. e is always the real, in-memory Meta - either
 // the one Save() is currently running for, or (via xref fan-out) one
-// resolved through Registry.FindResourceBySID()+FindMeta() rather than
+// resolved through Registry.FindResourceByXID()+FindMeta() rather than
 // a raw row.
 func (e *Entity) SaveXrefCascade() {
 	defer log.Trace("FullTree", e.Path)()
@@ -3998,9 +3862,7 @@ func (e *Entity) SaveXrefCascade() {
 
 // SaveXrefCascadeDelete clears this Meta's stale IsXrefPropCopy
 // rows and its Resource's stale IsXrefVerCopy rows, from whatever the
-// PREVIOUS xref state was. Split out from SaveXrefCascadeInsert so
-// VersionMetaPostSave() can run ALL deletes (this plus fullSaveOwnPropsDelete)
-// before either insert runs - see VersionMetaPostSave()'s ENTITY_META handling.
+// PREVIOUS xref state was.
 func (e *Entity) SaveXrefCascadeDelete() {
 	// e is always a real, in-memory Meta, which always has a parent
 	// Resource, so e.ParentSID is never empty here.

--- a/registry/entity.go
+++ b/registry/entity.go
@@ -2886,11 +2886,10 @@ func (e *Entity) ValidateMap(mapAttr *Attribute, val any, path *PropPath) *XRErr
 		Type:       mapAttr.Item.Type,
 		Item:       mapAttr.Item.Item,
 		Attributes: mapAttr.Item.Attributes,
-		// Enum:       e.CalcAttrEnum(mapAttr, path), // mapAttr.Enum,
+		Enum:       mapAttr.Enum,
 		Strict:    mapAttr.Strict,
 		MatchCase: mapAttr.MatchCase,
 	}
-	attr.Enum, _ = e.CalcAttrEnum(mapAttr, path)
 
 	for _, k := range valValue.MapKeys() {
 		if k.Kind() != reflect.String {
@@ -2951,11 +2950,10 @@ func (e *Entity) ValidateArray(arrayAttr *Attribute, val any, path *PropPath) *X
 		Type:       arrayAttr.Item.Type,
 		Item:       arrayAttr.Item.Item,
 		Attributes: arrayAttr.Item.Attributes,
-		// Enum:       e.CalcAttrEnum(arrayAttr, path), // arrayAttr.Enum,
+		Enum:       arrayAttr.Enum,
 		Strict:    arrayAttr.Strict,
 		MatchCase: arrayAttr.MatchCase,
 	}
-	attr.Enum, _ = e.CalcAttrEnum(arrayAttr, path)
 
 	for i := 0; i < valValue.Len(); i++ {
 		v := valValue.Index(i).Interface()
@@ -3207,8 +3205,10 @@ func (e *Entity) ValidateScalar(val any, attr *Attribute, path *PropPath) (*XREr
 		panic(fmt.Sprintf("Unknown type: %v", attr.Type))
 	}
 
-	// check against enum values - calc enum list from attr+constraints
-	enums, strict := e.CalcAttrEnum(attr, path)
+	// check against enum values - group-level "enum" constraints are
+	// enforced separately (and more completely, incl. xref-mirrored
+	// data) via Group.validateEnum(), not here.
+	enums, strict := attr.Enum, attr.GetStrict()
 	// log.Printf("Checking: %q: %q vs %q", attr.Name, val, EnumAsString(enums))
 	if strict && !IsValidEnum(val, enums, attr.GetMatchCase()) {
 		return NewXRError("invalid_attribute", e.XID,
@@ -3456,27 +3456,6 @@ func (e *Entity) CalcAttrDefault(attr *Attribute, path *PropPath) any {
 	}
 
 	return attr.Default
-}
-
-// return:   enum: []any , isStrict: bool
-func (e *Entity) CalcAttrEnum(attr *Attribute, path *PropPath) ([]any, bool) {
-	isStrict := attr.GetStrict()
-
-	if e.Type != ENTITY_VERSION {
-		return attr.Enum, isStrict
-	}
-
-	v := e.Self.(*Version)
-	g := v.Resource.Group
-
-	if c := g.GetAttrConstraint(v, attr, path); c != nil {
-		if len(c.Enum) > 0 {
-			// Enums from constraints are always "strict"
-			return c.Enum, true
-		}
-	}
-
-	return attr.Enum, isStrict
 }
 
 // EntityInsert adds a row to Entities for a newly-created

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1622,15 +1622,12 @@ func (r *Registry) VerifyData() *XRError {
 			resource.Self = resource
 			// onlyMetaChanged, forceVerify
 			//
-			// Unlike the other ValidateResource() call sites, this one
-			// is called directly (VerifyData() has callers - including
-			// tests - that invoke it via the Go API without ever going
-			// through an HTTP request/Tx.Validate()), so it must run
-			// synchronously here rather than being deferred via
-			// AddResourceToValidate().
-			if xErr = resource.ValidateResource(false, true); xErr != nil {
-				return xErr
-			}
+			// Deferred (not run synchronously here) so it goes through
+			// the same batching/merging logic as every other
+			// AddResourceToValidate() call site - r.Validate(nil) below
+			// drains it (along with GroupsToValidate) once all Resources
+			// and Versions in this loop have been marked/processed.
+			r.tx.AddResourceToValidate(resource, false, true)
 
 			// Skip xref'd resources, the real owner will do it.
 			// Note that we're assuming we're just skipping data validation.
@@ -1665,18 +1662,19 @@ func (r *Registry) VerifyData() *XRError {
 		}
 	}
 
-	// Drain any deferred Group constraint checks (GroupsToValidate) -
-	// this is the original gap this session set out to fix: VerifyData()
-	// never checked group-level equals/enum cross-attribute constraints
-	// on model changes. Must run last, after all per-Version attribute
-	// validation above, so a more specific per-attribute error (e.g. an
-	// "enum" violation reported as invalid_attribute) isn't masked by
-	// Group.Validate()'s more generic "constraint_failure" for the same
-	// violation.
-	for _, g := range r.tx.GroupsToValidate {
-		if xErr := g.Validate(); xErr != nil {
-			return xErr
-		}
+	// Drain any deferred Resource validation (marked just above via
+	// AddResourceToValidate()) and Group constraint checks
+	// (GroupsToValidate) - this is the original gap this session set
+	// out to fix: VerifyData() never checked group-level equals/enum
+	// cross-attribute constraints on model changes, and (as of this
+	// change) no longer runs ValidateResource() synchronously either,
+	// so both are drained together via the same Registry.Validate()
+	// used by every HTTP request (Tx.Validate()). Must run last, after
+	// all per-Version attribute validation above, so a more specific
+	// per-attribute error isn't masked by a more generic one for the
+	// same violation.
+	if xErr := r.Validate(nil); xErr != nil {
+		return xErr
 	}
 
 	return nil

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -116,10 +116,9 @@ func (r *Registry) Validate(info *RequestInfo) *XRError {
 	// Loops until the map is empty since running ValidateResource() can,
 	// in theory, cause further marks (e.g. Resource.EnsureLatest() saving
 	// a Meta), with a safety cap to avoid an infinite loop should that
-	// ever cycle unexpectedly. Must run before we lock the Tx below
-	// since validation itself still needs to write, and must run before
-	// GroupsToValidate since constraint checks may depend on
-	// cascade-derived mirrored data (e.g. isdefault).
+	// ever cycle unexpectedly. Must run before GroupsToValidate since
+	// constraint checks may depend on cascade-derived mirrored data
+	// (e.g. isdefault).
 	for i := 0; len(tx.ResourcesToValidate) > 0; i++ {
 		if i >= 20 {
 			return NewXRError("server_error", "/").SetDetail(
@@ -142,9 +141,6 @@ func (r *Registry) Validate(info *RequestInfo) *XRError {
 		}
 		tx.ResourcesValidatingBatch = nil
 	}
-
-	// If not already locked, lock it
-	tx.Lock()
 
 	for _, g := range tx.GroupsToValidate {
 		if xErr := g.Validate(); xErr != nil {
@@ -1648,9 +1644,13 @@ func (r *Registry) VerifyData() *XRError {
 				continue
 			}
 
-			// Now do Versions
-			entities, xErr = RawEntitiesFromQuery(r.tx, r.DbSID, FOR_WRITE,
-				`e.ParentSID=?`, resource.DbSID)
+			// Now do Versions. Filter to just ENTITY_VERSION - a
+			// Resource's Meta shares the same ParentSID
+			// (resource.DbSID), so without this filter we'd also pick
+			// up the Meta row here and mis-process it as a Version.
+			entities, xErr := RawEntitiesFromQuery(r.tx, r.DbSID, FOR_WRITE,
+				fmt.Sprintf(`e.ParentSID=? AND e.Type=%d`, ENTITY_VERSION),
+				resource.DbSID)
 			if xErr != nil {
 				return xErr
 			}
@@ -1663,7 +1663,20 @@ func (r *Registry) VerifyData() *XRError {
 				}
 			}
 		}
+	}
 
+	// Drain any deferred Group constraint checks (GroupsToValidate) -
+	// this is the original gap this session set out to fix: VerifyData()
+	// never checked group-level equals/enum cross-attribute constraints
+	// on model changes. Must run last, after all per-Version attribute
+	// validation above, so a more specific per-attribute error (e.g. an
+	// "enum" violation reported as invalid_attribute) isn't masked by
+	// Group.Validate()'s more generic "constraint_failure" for the same
+	// violation.
+	for _, g := range r.tx.GroupsToValidate {
+		if xErr := g.Validate(); xErr != nil {
+			return xErr
+		}
 	}
 
 	return nil

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1414,44 +1414,6 @@ func (r *Registry) FindXIDGroup(xidStr string, path string) (*Group, *XRError) {
 	return r.FindGroup(xid.Group, xid.GroupID, false, FOR_READ)
 }
 
-// FindResourceBySID resolves a Resource's SID to its real, in-memory
-// *Resource - going through the normal FindGroup()/FindResource() path
-// (cache-checked first, DB-read-and-cached on a miss) rather than
-// building a partial/synthetic shell from raw row data. Used by code
-// (e.g. xref fan-out) that only discovers a Resource's SID via a query
-// (Metas.xRefPath, etc.) and has no path/XID string on hand - a small
-// join against Resources/Groups gets us the type names+UIDs needed to
-// go through the real finder functions, so callers get a fully-wired
-// Resource (correct Group/Registry pointers) instead of a fragile
-// hand-built stand-in.
-func (r *Registry) FindResourceBySID(sid string, accessMode int) (*Resource, *XRError) {
-	if sid == "" {
-		return nil, nil
-	}
-
-	results := Query(r.tx, `
-        SELECT g.Plural, g.UID, res.Plural, res.UID
-        FROM Resources AS res
-        JOIN "Groups" AS g ON (g.SID=res.GroupSID)
-        WHERE res.SID=?`, sid)
-	row := results.NextRow()
-	results.Close()
-	if row == nil {
-		return nil, nil
-	}
-
-	groupPlural := NotNilString(row[0])
-	groupUID := NotNilString(row[1])
-	resPlural := NotNilString(row[2])
-	resUID := NotNilString(row[3])
-
-	g, xErr := r.FindGroup(groupPlural, groupUID, false, accessMode)
-	if xErr != nil || g == nil {
-		return nil, xErr
-	}
-	return g.FindResource(resPlural, resUID, false, accessMode)
-}
-
 func (r *Registry) FindResourceByXID(xidStr string, path string, accessMode int) (*Resource, *XRError) {
 	xid, err := ParseXid(xidStr)
 	if err != nil {

--- a/registry/resource.go
+++ b/registry/resource.go
@@ -1253,33 +1253,28 @@ func (r *Resource) UpsertVersionWithObject(vu *VersionUpsert) (*Version, bool, *
 }
 
 // checkHasDocumentViolation returns non-nil XRError if hasdocument=false
-// but any versions have document content stored in ResourceContents DB table
-// or have singular/singularurl/singularproxyurl attributes set.
+// but any versions have document content stored in the ResourceContents DB
+// table. Note: this deliberately does NOT look at whether
+// singular/singularurl/singularproxyurl Props are set - those are only
+// reserved attribute names when hasdocument=true (see AddAttribute() in
+// shared_model.go), so when hasdocument=false a user may have legitimately
+// defined one of those exact names as their own extension attribute (or
+// used a "*" wildcard extension). That data is 100% valid and must not be
+// flagged here. If no such extension is defined, the generic attribute
+// validator (run elsewhere, on every PUT) already correctly rejects it as
+// an unknown_attribute - there's no need to duplicate that check here.
+// The one thing generic attribute validation can never see is actual
+// stored document bytes, which can never be legal once hasdocument=false -
+// that's the only thing left to check for.
 func (r *Resource) checkHasDocumentViolation() *XRError {
-	singular := r.ResourceModel.Singular
-
-	// Query for any versions with document content in ResourceContents table
-	// or with singular/singularurl/singularproxyurl attributes in
-	// Props. Note: PropName includes DB_IN delimiter at the end
-	// (e.g., "fileurl,")
-	query := fmt.Sprintf(`
+	query := `
 		SELECT v.Path FROM Versions v
 		WHERE v.ResourceSID = ?
-		AND (
-			EXISTS (
-				SELECT 1 FROM ResourceContents rc
-				WHERE rc.VersionSID = v.SID
-			)
-			OR EXISTS (
-				SELECT 1 FROM Props p
-				WHERE p.eSID = v.SID
-				AND p.IsDefaultVerCopy=false AND p.IsXrefPropCopy=false
-				AND p.IsXrefVerCopy=false
-				AND p.PropName IN ('%s%s', '%surl%s', '%sproxyurl%s')
-			)
+		AND EXISTS (
+			SELECT 1 FROM ResourceContents rc
+			WHERE rc.VersionSID = v.SID
 		)
-		LIMIT 1`, singular, string(DB_IN), singular, string(DB_IN),
-		singular, string(DB_IN))
+		LIMIT 1`
 
 	results := Query(r.tx, query, r.DbSID)
 	defer results.Close()
@@ -2675,6 +2670,16 @@ func (r *Resource) SaveXrefFanOutForTarget() {
 		sourceMeta.SaveXrefCascade()
 		sourceResource.SaveXrefVersionCopies(r.DbSID)
 		sourceResource.SaveDefaultVersionCascade()
+
+		// The mirrored data we just (re-)copied into sourceResource may
+		// now violate sourceResource's own Group's "equals"/"enum"
+		// constraints (e.g. this xref target's attribute value changed
+		// to something the source's group doesn't allow) - mark that
+		// Group for constraint re-validation so GroupsToValidate
+		// catches it before this Tx commits/responds. Without this,
+		// a target update could silently leave a xref source's mirror
+		// in a group-non-compliant state.
+		r.tx.AddGroupToValidate(sourceResource.Group)
 	}
 }
 

--- a/registry/resource.go
+++ b/registry/resource.go
@@ -1311,7 +1311,7 @@ func (r *Resource) ValidateResource(onlyMetaChanged bool, force bool) *XRError {
 	// Registry.Validate() would redundantly run ValidateResource() for
 	// r again later in this same Tx (e.g. a Version/Meta save that
 	// happened as part of this very call already marked r via
-	// Entity.VersionMetaPostSave()). Also drop it from ResourcesValidatingBatch
+	// Entity.Save()). Also drop it from ResourcesValidatingBatch
 	// (if present) - see that field's doc comment - so any other
 	// xref source's runCascade() checking "is my target still pending
 	// in this batch" correctly sees that r's own validation (and its
@@ -1323,7 +1323,7 @@ func (r *Resource) ValidateResource(onlyMetaChanged bool, force bool) *XRError {
 
 	// On the way out, delete any mark this call's OWN body may have
 	// re-added to ResourcesToValidate (e.g. EnsureLatest()'s
-	// meta.SetSave("defaultversionid", ...) -> Entity.VersionMetaPostSave()
+	// meta.SetSave("defaultversionid", ...) -> Entity.Save()
 	// -> AddResourceToValidate()) - this call is about to account for
 	// that change itself (via runCascade() below), so leaving that
 	// self-mark in place would cause a second, fully redundant
@@ -2492,7 +2492,7 @@ func (r *Resource) SaveDefaultVersionCascade() {
 // SaveXrefVersionCopies (re)creates the synthetic Entities/
 // Props Version rows for srcResource (a real, in-memory
 // *Resource - either e.Self.(*Meta).Resource in the direct-Save() case,
-// or one resolved via Registry.FindResourceBySID() in the xref fan-out
+// or one resolved via Registry.FindResourceByXID() in the xref fan-out
 // case)
 // that xrefs targetResourceSID, one set of rows per Version the target
 // currently has - all done via set-based SQL (no per-Version Go loop/
@@ -2628,18 +2628,24 @@ func (srcResource *Resource) SaveXrefVersionCopies(targetResourceSID string) {
 // xrefs r - used whenever either r's Meta or one of r's Versions
 // (something that makes r someone else's xref target) is saved. r is
 // the real, in-memory *Resource whose Meta/Version was just saved
-// (always available at the VersionMetaPostSave() call site as meta.Resource or
+// (always available at the Entity.Save() call site as meta.Resource or
 // v.Resource). This combines what used to be two separate functions
 // (fullSaveXrefFanOutForTargetMeta/fullSaveXrefFanOutForTargetVersion)
 // - they were always called back-to-back from the same runCascade()
 // call site, each running its own copy of the identical "who xrefs me"
 // query and its own SaveDefaultVersionCascade(sourceResource) call, so
 // merging them halves both the query count and the redundant
-// per-source default-version cascade work. Each source discovered here
-// is resolved to its own real *Resource/*Meta via
-// Registry.FindResourceBySID()/FindMeta() (cache-checked, so repeat
-// fan-out hits for the same source within one Tx are free) rather than
-// a raw fullEntityLookup() row.
+// per-source default-version cascade work. The query below joins
+// straight through to Resources to grab each source's own Path
+// (already exactly "groupPlural/groupUID/resPlural/resUID" - see
+// where it's written at Resource creation), rather than just
+// returning its SID and needing a separate lookup query to turn that
+// SID back into the Group/Resource plural+UID FindGroup()/
+// FindResource() need (what Registry.FindResourceBySID() used to do)
+// - so each source is resolved via Registry.FindResourceByXID()/
+// FindMeta() (cache-checked, so repeat fan-out hits for the same
+// source within one Tx are free) with no extra DB round trip beyond
+// this one query.
 func (r *Resource) SaveXrefFanOutForTarget() {
 	if r == nil {
 		return
@@ -2648,14 +2654,17 @@ func (r *Resource) SaveXrefFanOutForTarget() {
 	defer log.Trace("FullTree", r.XID)()
 
 	results := Query(r.tx, `
-        SELECT ResourceSID FROM Metas WHERE RegistrySID=? AND xRefPath=?`,
+        SELECT res.Path
+        FROM Metas AS m
+        JOIN Resources AS res ON (res.SID=m.ResourceSID)
+        WHERE m.RegistrySID=? AND m.xRefPath=?`,
 		r.Registry.DbSID, r.Path)
 	defer results.Close()
 
 	for row := results.NextRow(); row != nil; row = results.NextRow() {
-		sourceResourceSID := NotNilString(row[0])
-		sourceResource, xErr := r.tx.Registry.FindResourceBySID(
-			sourceResourceSID, FOR_WRITE)
+		sourceXID := "/" + NotNilString(row[0])
+		sourceResource, xErr := r.tx.Registry.FindResourceByXID(
+			sourceXID, r.Path, FOR_WRITE)
 		if xErr != nil || sourceResource == nil {
 			continue
 		}

--- a/tests/constraints_test.go
+++ b/tests/constraints_test.go
@@ -1882,14 +1882,15 @@ func TestConstraintsGroupTypeRuntime(t *testing.T) {
       }}}}}},
       "dirs": { "d1": { "files": { "f1": {"name":"c"}}}} }`, 400,
 		`{
-  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#invalid_attribute",
-  "title": "The attribute \"name\" for \"/dirs/d1/files/f1/versions/1\" is not valid: value (c) must be one of the enum values: a, b.",
-  "subject": "/dirs/d1/files/f1/versions/1",
+  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#constraint_failure",
+  "title": "The request would result in one or more Versions of \"/dirs/d1/files/f1\" not being compliant with its owning Group's \"enum\" constraint for attribute \"name\".",
+  "detail": "Versions: 1. Must be one of: a, b.",
+  "subject": "/dirs/d1/files/f1",
   "args": {
-    "error_detail": "value (c) must be one of the enum values: a, b",
-    "name": "name"
+    "kind": "enum",
+    "path": "name"
   },
-  "source": "3ba414aa22c1:registry:entity:2945"
+  "source": ":registry:group:969"
 }
 `)
 
@@ -2039,9 +2040,20 @@ func TestConstraintsGroupTypeRuntime(t *testing.T) {
 		`{"dirs":{"d1":{"name":"n","files":{"f1":{}}}} }`, 200,
 		`^(?s)^.*"name": "n",\n *"createdat.*"name": "n",\n *"isdefault"`)
 
-	// Update f1, bad name
-	XHTTP(t, reg, "PUT", "/dirs/d1/files/f1", `{"name": "y"}`, 400,
-		`^(?s)^.*invalid_attribute.*value \(y\).* n, z`)
+	// Update f1, bad name (fails BOTH "equals" and "enum" - "equals"
+	// is checked first by Group.Validate())
+	XHTTP(t, reg, "PUT", "/dirs/d1/files/f1", `{"name": "y"}`, 400, `{
+  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#constraint_failure",
+  "title": "The request would result in one or more Versions of \"/dirs/d1/files/f1\" not being compliant with its owning Group's \"equals\" constraint for attribute \"name\".",
+  "detail": "Versions: 1.",
+  "subject": "/dirs/d1/files/f1",
+  "args": {
+    "kind": "equals",
+    "path": "name"
+  },
+  "source": ":registry:group:895"
+}
+`)
 
 	// Update f1, good alt name, but fails "equals" constraint
 	XHTTP(t, reg, "PUT", "/dirs/d1/files/f1", `{"name": "z"}`, 400,
@@ -2084,8 +2096,18 @@ func TestConstraintsGroupTypeRuntime(t *testing.T) {
       },
 	  "resources": {"files": {"singular":"file", "hasdocument":false,
         "attributes": {
-      }}}}}}`, 400,
-		`^(?s)^.*invalid_attribute.*\\"name\\".*value \(y\).*a, b`)
+      }}}}}}`, 400, `{
+  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#constraint_failure",
+  "title": "The request would result in one or more Versions of \"/dirs/d1/files/f1\" not being compliant with its owning Group's \"enum\" constraint for attribute \"name\".",
+  "detail": "Versions: 1. Must be one of: a, b.",
+  "subject": "/dirs/d1/files/f1",
+  "args": {
+    "kind": "enum",
+    "path": "name"
+  },
+  "source": ":registry:group:969"
+}
+`)
 }
 
 func TestConstraintsGroupErrors(t *testing.T) {
@@ -2427,8 +2449,18 @@ func TestConstraintsGroupRuntime(t *testing.T) {
       }}}}}},
       "dirs":{"d1":{
         "constraints":{"files.name":{"enum":["n","z"]}},
-        "files":{"f1":{"name":"c"}}}} }`, 400,
-		`^(?s)^.*invalid_attribute.*value \(c\).* n, z".*"name": "name"`)
+        "files":{"f1":{"name":"c"}}}} }`, 400, `{
+  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#constraint_failure",
+  "title": "The request would result in one or more Versions of \"/dirs/d1/files/f1\" not being compliant with its owning Group's \"enum\" constraint for attribute \"name\".",
+  "detail": "Versions: 1. Must be one of: n, z.",
+  "subject": "/dirs/d1/files/f1",
+  "args": {
+    "kind": "enum",
+    "path": "name"
+  },
+  "source": ":registry:group:969"
+}
+`)
 
 	// g.enum present, f1 present (in enum)
 	XHTTP(t, reg, "PUT", "/?inline=dirs.files", `{"modelsource": {
@@ -2451,8 +2483,18 @@ func TestConstraintsGroupRuntime(t *testing.T) {
         "files":{"f2":{"name":null}}}} }`, 200,
 		`^(?s)^.*"epoch": 1,\n *"isdefault`) // no "name"
 
-	XHTTP(t, reg, "PUT", "/dirs/d1/files/f2$details", `{"name":"y"}`, 400,
-		`^(?s)^.*invalid_attribute.*value \(y\) must.* n, z.*"name": "name"`)
+	XHTTP(t, reg, "PUT", "/dirs/d1/files/f2$details", `{"name":"y"}`, 400, `{
+  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#constraint_failure",
+  "title": "The request would result in one or more Versions of \"/dirs/d1/files/f2\" not being compliant with its owning Group's \"enum\" constraint for attribute \"name\".",
+  "detail": "Versions: 1. Must be one of: n, z.",
+  "subject": "/dirs/d1/files/f2",
+  "args": {
+    "kind": "enum",
+    "path": "name"
+  },
+  "source": ":registry:group:969"
+}
+`)
 
 	XHTTP(t, reg, "PUT", "/dirs/d1/files/f2$details", `{"name":"n"}`, 200,
 		`^(?s)^.*"name": "n"`)
@@ -2508,9 +2550,20 @@ func TestConstraintsGroupRuntime(t *testing.T) {
 	XHTTP(t, reg, "PUT", "/dirs/d1/files/f1", `{}`, 200,
 		`^(?s)^.*"name": "n"`)
 
-	// Update file - bad attr
-	XHTTP(t, reg, "PUT", "/dirs/d1/files/f1", `{"name":"y"}`, 400,
-		`^(?s)^.*invalid_attribute.*value \(y\).* n, z`)
+	// Update file - bad attr (fails BOTH "equals" and "enum" - "equals"
+	// is checked first by Group.Validate())
+	XHTTP(t, reg, "PUT", "/dirs/d1/files/f1", `{"name":"y"}`, 400, `{
+  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#constraint_failure",
+  "title": "The request would result in one or more Versions of \"/dirs/d1/files/f1\" not being compliant with its owning Group's \"equals\" constraint for attribute \"name\".",
+  "detail": "Versions: 1.",
+  "subject": "/dirs/d1/files/f1",
+  "args": {
+    "kind": "equals",
+    "path": "name"
+  },
+  "source": ":registry:group:895"
+}
+`)
 
 	// Update group - missing attr
 	XHTTP(t, reg, "PATCH", "/dirs/d1", `{"name":null}`, 200,
@@ -2613,8 +2666,18 @@ func TestConstraintsLayering(t *testing.T) {
 	  "dirs":{"d1":{
 	    "name": "c",
 	    "constraints":{"files.name":{"equals":"name"}},
-	    "files":{"f1":{"name":"c"}}}}}`, 400,
-		`^(?s)^.*invalid_attribute`)
+	    "files":{"f1":{"name":"c"}}}}}`, 400, `{
+  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#constraint_failure",
+  "title": "The request would result in one or more Versions of \"/dirs/d1/files/f1\" not being compliant with its owning Group's \"enum\" constraint for attribute \"name\".",
+  "detail": "Versions: 1. Must be one of: a, b.",
+  "subject": "/dirs/d1/files/f1",
+  "args": {
+    "kind": "enum",
+    "path": "name"
+  },
+  "source": ":registry:group:969"
+}
+`)
 
 	// --- Case 4: gm.{equals:"name"} + g.{default:"n"} ---
 	// Success: g.default matches group.name so equals constraint is satisfied
@@ -2679,8 +2742,18 @@ func TestConstraintsLayering(t *testing.T) {
 	  "dirs":{"d1":{
 	    "name": "c",
 	    "constraints":{"files.name":{"enum":["a","b"]}},
-	    "files":{"f1":{"name":"c"}}}}}`, 400,
-		`^(?s)^.*invalid_attribute`)
+	    "files":{"f1":{"name":"c"}}}}}`, 400, `{
+  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#constraint_failure",
+  "title": "The request would result in one or more Versions of \"/dirs/d1/files/f1\" not being compliant with its owning Group's \"enum\" constraint for attribute \"name\".",
+  "detail": "Versions: 1. Must be one of: a, b.",
+  "subject": "/dirs/d1/files/f1",
+  "args": {
+    "kind": "enum",
+    "path": "name"
+  },
+  "source": ":registry:group:969"
+}
+`)
 
 	// --- Case 6: gm.{default:"a",enum:["a","b"]} + g.{equals:"name"} ---
 	// Success: resource gets gm.default, in gm.enum, equals group.name
@@ -2902,14 +2975,34 @@ func TestConstraintsMultipleResourceTypes(t *testing.T) {
 	// Constraints don't bleed: file with "doc-other" is rejected
 	// (not in files enum)
 	XHTTP(t, reg, "PUT", "/dirs/d1/files/f2$details",
-		`{"mystr":"doc-other"}`, 400,
-		`^(?s)^.*invalid_attribute`)
+		`{"mystr":"doc-other"}`, 400, `{
+  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#constraint_failure",
+  "title": "The request would result in one or more Versions of \"/dirs/d1/files/f2\" not being compliant with its owning Group's \"enum\" constraint for attribute \"mystr\".",
+  "detail": "Versions: 1. Must be one of: file-default, file-other.",
+  "subject": "/dirs/d1/files/f2",
+  "args": {
+    "kind": "enum",
+    "path": "mystr"
+  },
+  "source": ":registry:group:969"
+}
+`)
 
 	// Constraints don't bleed: doc with "file-other" is rejected
 	// (not in docs enum)
 	XHTTP(t, reg, "PUT", "/dirs/d1/docs/d2$details",
-		`{"mystr":"file-other"}`, 400,
-		`^(?s)^.*invalid_attribute`)
+		`{"mystr":"file-other"}`, 400, `{
+  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#constraint_failure",
+  "title": "The request would result in one or more Versions of \"/dirs/d1/docs/d2\" not being compliant with its owning Group's \"enum\" constraint for attribute \"mystr\".",
+  "detail": "Versions: 1. Must be one of: doc-default, doc-other.",
+  "subject": "/dirs/d1/docs/d2",
+  "args": {
+    "kind": "enum",
+    "path": "mystr"
+  },
+  "source": ":registry:group:969"
+}
+`)
 
 	// Valid values within each type's enum work fine
 	XHTTP(t, reg, "PUT", "/dirs/d1/files/f3$details",
@@ -2939,8 +3032,18 @@ func TestConstraintsMultipleResourceTypes(t *testing.T) {
 	    "constraints":{
 	      "files.mystr":{"enum":["file-default"]}
 	    },
-	    "files":{"f2":{"mystr":"file-other"}}}}}`, 400,
-		`^(?s)^.*invalid_attribute`)
+	    "files":{"f2":{"mystr":"file-other"}}}}}`, 400, `{
+  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#constraint_failure",
+  "title": "The request would result in one or more Versions of \"/dirs/d3/files/f2\" not being compliant with its owning Group's \"enum\" constraint for attribute \"mystr\".",
+  "detail": "Versions: 1. Must be one of: file-default.",
+  "subject": "/dirs/d3/files/f2",
+  "args": {
+    "kind": "enum",
+    "path": "mystr"
+  },
+  "source": ":registry:group:969"
+}
+`)
 
 	reg.Model.SetChanged(false)
 }
@@ -3033,8 +3136,18 @@ func TestConstraintsDeepNestedPath(t *testing.T) {
 
 	// Error: a.b.c value not in enum
 	XHTTP(t, reg, "PUT", "/?inline=dirs.files", `{"modelsource": `+modelSrc+`,
-	  "dirs":{"d1":{"files":{"f1":{"a":{"b":{"c":"z"}}}}}}}`, 400,
-		`^(?s)^.*invalid_attribute`)
+	  "dirs":{"d1":{"files":{"f1":{"a":{"b":{"c":"z"}}}}}}}`, 400, `{
+  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#constraint_failure",
+  "title": "The request would result in one or more Versions of \"/dirs/d1/files/f1\" not being compliant with its owning Group's \"enum\" constraint for attribute \"a.b.c\".",
+  "detail": "Versions: 1. Must be one of: x, y.",
+  "subject": "/dirs/d1/files/f1",
+  "args": {
+    "kind": "enum",
+    "path": "a.b.c"
+  },
+  "source": ":registry:group:969"
+}
+`)
 
 	// Model error: path stops at non-object
 	modelSrcBadPath := `{
@@ -3088,8 +3201,18 @@ func TestConstraintsGroupInstanceNewKey(t *testing.T) {
 		`^(?s)^.*"myint": 5.*"mystr": "a"`)
 
 	// Both constraints apply: gm.enum for mystr
-	XHTTP(t, reg, "PUT", "/dirs/d1/files/f2$details", `{"mystr":"c"}`, 400,
-		`^(?s)^.*invalid_attribute`)
+	XHTTP(t, reg, "PUT", "/dirs/d1/files/f2$details", `{"mystr":"c"}`, 400, `{
+  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#constraint_failure",
+  "title": "The request would result in one or more Versions of \"/dirs/d1/files/f2\" not being compliant with its owning Group's \"enum\" constraint for attribute \"mystr\".",
+  "detail": "Versions: 1. Must be one of: a, b.",
+  "subject": "/dirs/d1/files/f2",
+  "args": {
+    "kind": "enum",
+    "path": "mystr"
+  },
+  "source": ":registry:group:969"
+}
+`)
 
 	// Both constraints apply: g.default for myint even with explicit mystr
 	XHTTP(t, reg, "PUT", "/dirs/d1/files/f2$details", `{"mystr":"b"}`, 201,
@@ -3510,14 +3633,15 @@ func TestConstraintsEnumEnforcedOnXref(t *testing.T) {
 	// resource in d2 with myattr="c" (not in the enum) fails.
 	XHTTP(t, reg, "PUT", "/dirs/d2/files/real$details",
 		`{"myattr":"c"}`, 400, `{
-  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#invalid_attribute",
-  "title": "The attribute \"myattr\" for \"/dirs/d2/files/real/versions/1\" is not valid: value (c) must be one of the enum values: a, b.",
-  "subject": "/dirs/d2/files/real/versions/1",
+  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#constraint_failure",
+  "title": "The request would result in one or more Versions of \"/dirs/d2/files/real\" not being compliant with its owning Group's \"enum\" constraint for attribute \"myattr\".",
+  "detail": "Versions: 1. Must be one of: a, b.",
+  "subject": "/dirs/d2/files/real",
   "args": {
-    "error_detail": "value (c) must be one of the enum values: a, b",
-    "name": "myattr"
+    "kind": "enum",
+    "path": "myattr"
   },
-  "source": ":registry:entity:3203"
+  "source": ":registry:group:969"
 }
 `)
 
@@ -3599,11 +3723,13 @@ func TestConstraintsEnumEnforcedOnXref(t *testing.T) {
 // direction/timing from the two tests above: a xref is created first
 // while fully compliant with its own group's "equals"/"enum" constraints,
 // then the TARGET is later updated to a value that would violate those
-// constraints (via its mirrored value). Since the constraint truly
-// belongs to the xref SOURCE's group (not the target's), the target's
-// own update must succeed (it isn't itself constrained) - but the
-// resulting xref mirror update, if/when re-validated, is what would need
-// to be caught. This documents current behavior for that scenario.
+// constraints (via its mirrored value). The constraint truly belongs to
+// the xref SOURCE's group (not the target's), so the target's own group
+// (d1) never rejects the value itself - but SaveXrefFanOutForTarget()
+// marks the source's Group (d2) for constraint re-validation as part of
+// the same Tx, so the overall request is rejected (and fully rolled
+// back - neither t1 nor its xref mirror fx are changed) once d2's
+// GroupsToValidate drain catches the now-non-compliant mirrored value.
 func TestConstraintsViolationOnTargetUpdateAfterXref(t *testing.T) {
 	reg := NewRegistry("TestConstraintsViolationOnTargetUpdateAfterXref")
 	defer PassDeleteReg(t, reg)
@@ -3695,24 +3821,38 @@ func TestConstraintsViolationOnTargetUpdateAfterXref(t *testing.T) {
 `)
 
 	// Now update t1 (in the UNCONSTRAINED d1) to a value that would
-	// violate d2's enum. t1's own save succeeds (d1 has no constraint
-	// on myattr), and its cascade updates fx's mirrored value too -
-	// current behavior does NOT re-run d2's Group.Validate() as part of
-	// t1's save (only d1's own group is re-validated on a group-level
-	// save), so this succeeds even though fx now mirrors a
-	// constraint-violating value for d2.
+	// violate d2's enum via its xref mirror. t1's own group (d1) has no
+	// constraint on myattr, but SaveXrefFanOutForTarget() marks d2 (fx's
+	// hosting group) for constraint re-validation as part of this same
+	// Tx, so the whole request is rejected - and fully rolled back, see
+	// the two GETs below - once d2's GroupsToValidate drain catches the
+	// now-non-compliant mirrored value.
 	XHTTP(t, reg, "PATCH", "/dirs/d1/files/t1$details",
-		`{"myattr":"c"}`, 200, `{
+		`{"myattr":"c"}`, 400, `{
+  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#constraint_failure",
+  "title": "The request would result in one or more Versions of \"/dirs/d2/files/fx\" not being compliant with its owning Group's \"enum\" constraint for attribute \"myattr\".",
+  "detail": "Versions: 1. Must be one of: a, b.",
+  "subject": "/dirs/d2/files/fx",
+  "args": {
+    "kind": "enum",
+    "path": "myattr"
+  },
+  "source": ":registry:group:969"
+}
+`)
+	// t1 itself must be unchanged - the whole Tx rolled back.
+	XHTTP(t, reg, "GET", "/dirs/d1/files/t1$details", ``, 200,
+		`{
   "fileid": "t1",
   "versionid": "1",
   "self": "http://localhost:8181/dirs/d1/files/t1",
   "xid": "/dirs/d1/files/t1",
-  "epoch": 2,
+  "epoch": 1,
   "isdefault": true,
   "createdat": "2026-07-27T00:25:25.573062855Z",
-  "modifiedat": "2026-07-27T00:25:25.693362417Z",
+  "modifiedat": "2026-07-27T00:25:25.573062855Z",
   "ancestorid": "1",
-  "myattr": "c",
+  "myattr": "a",
 
   "metaurl": "http://localhost:8181/dirs/d1/files/t1/meta",
   "versionsurl": "http://localhost:8181/dirs/d1/files/t1/versions",
@@ -3725,12 +3865,12 @@ func TestConstraintsViolationOnTargetUpdateAfterXref(t *testing.T) {
   "versionid": "1",
   "self": "http://localhost:8181/dirs/d2/files/fx",
   "xid": "/dirs/d2/files/fx",
-  "epoch": 2,
+  "epoch": 1,
   "isdefault": true,
   "createdat": "2026-07-27T00:25:27.731699639Z",
-  "modifiedat": "2026-07-27T00:25:27.857600485Z",
+  "modifiedat": "2026-07-27T00:25:27.731699639Z",
   "ancestorid": "1",
-  "myattr": "c",
+  "myattr": "a",
 
   "metaurl": "http://localhost:8181/dirs/d2/files/fx/meta",
   "versionsurl": "http://localhost:8181/dirs/d2/files/fx/versions",
@@ -4160,4 +4300,306 @@ func TestConstraintsMultipleConstraintSourcesXrefCascade(t *testing.T) {
   "versionscount": 1
 }
 `)
+}
+
+func TestConstraintsWithXrefs(t *testing.T) {
+	reg := NewRegistry("TestConstraintsWithXrefs")
+	defer PassDeleteReg(t, reg)
+
+	// good: import with xref + group constraints
+	model := `{
+  "modelsource": {
+    "groups": {
+      "dirs": { "singular": "dir",
+        "constraints": {
+          "files.name": { "equals": "name", "enum": [ "joe", "mary" ] }
+        },
+        "resources": {
+          "files": { "singular": "file" }
+        }
+      },
+      "datas": { "singular": "data",
+        "ximportresources": [ "/dirs/files" ],
+        "constraints": {
+          "files.name": { "equals": "name", "enum": [ "joe" ] }
+        }
+      }
+    }
+  },
+  "dirs": {
+    "d1": {
+      "name": "joe",
+      "files": { "f1": { "name": "joe" } }
+    }
+  },
+  "datas": {
+    "da1": {
+      "name": "joe",
+      "files": { "fx": { "meta": { "xref": "/dirs/d1/files/f1" } } }
+    }
+  }
+}
+`
+	XHTTP(t, reg, "PUT", "/", model, 200, `{
+  "specversion": "1.0-rc3",
+  "registryid": "TestConstraintsWithXrefs",
+  "self": "http://localhost:8181/",
+  "xid": "/",
+  "epoch": 2,
+  "createdat": "2026-08-01T17:02:32.860014368Z",
+  "modifiedat": "2026-08-01T17:02:32.871987984Z",
+
+  "datasurl": "http://localhost:8181/datas",
+  "datascount": 1,
+  "dirsurl": "http://localhost:8181/dirs",
+  "dirscount": 1
+}
+`)
+
+	// bad: import with xref + group constraints / enum bad
+	model = `{
+  "modelsource": {
+    "groups": {
+      "dirs": { "singular": "dir",
+        "constraints": {
+          "files.name": { "equals": "name", "enum": [ "joe", "mary" ] }
+        },
+        "resources": {
+          "files": { "singular": "file" }
+        }
+      },
+      "datas": { "singular": "data",
+        "ximportresources": [ "/dirs/files" ],
+        "constraints": {
+          "files.name": { "equals": "name", "enum": [ "joe" ] }
+        }
+      }
+    }
+  },
+  "dirs": {
+    "d1": {
+      "name": "joe",
+      "files": { "f1": { "name": "joe" } }
+    }
+  },
+  "datas": {
+    "da1": {
+      "name": "mary",
+      "files": { "fx": { "meta": { "xref": "/dirs/d1/files/f1" } } }
+    }
+  }
+}
+`
+	XHTTP(t, reg, "PUT", "/", model, 400, `{
+  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#constraint_failure",
+  "title": "The request would result in one or more Versions of \"/datas/da1/files/fx\" not being compliant with its owning Group's \"equals\" constraint for attribute \"name\".",
+  "detail": "Versions: 1.",
+  "subject": "/datas/da1/files/fx",
+  "args": {
+    "kind": "equals",
+    "path": "name"
+  },
+  "source": "d201b31810dc:registry:group:895"
+}
+`)
+
+	// Now just the model part
+	model = `{
+  "groups": {
+    "dirs": {
+      "singular": "dir",
+      "constraints": {
+        "files.name": {
+          "equals": "name",
+          "enum": [
+            "joe",
+            "mary"
+          ]
+        }
+      },
+      "resources": {
+        "files": {
+          "singular": "file"
+        }
+      }
+    },
+    "datas": {
+      "singular": "data",
+      "ximportresources": [
+        "/dirs/files"
+      ],
+      "constraints": {
+        "files.name": {
+          "equals": "name",
+          "enum": [
+            "joe"
+          ]
+        }
+      }
+    }
+  }
+}
+`
+
+	// Clear everything first
+	XHTTP(t, reg, "DELETE", "/dirs", "", 204, "")
+	XHTTP(t, reg, "DELETE", "/datas", "", 204, "")
+
+	XHTTP(t, reg, "PUT", "/modelsource", model, 200, model)
+
+	// Create d1 - ok
+	XHTTP(t, reg, "PUT", "/dirs/d1", `{"name":"joe"}`, 201, `{
+  "dirid": "d1",
+  "self": "http://localhost:8181/dirs/d1",
+  "xid": "/dirs/d1",
+  "epoch": 1,
+  "name": "joe",
+  "createdat": "2026-08-01T19:50:04.233260699Z",
+  "modifiedat": "2026-08-01T19:50:04.233260699Z",
+
+  "filesurl": "http://localhost:8181/dirs/d1/files",
+  "filescount": 0
+}
+`)
+
+	// Now f1 - bad - name needs to be "joe" (plus in enum)
+	XHTTP(t, reg, "PUT", "/dirs/d1/files/f1$details", `{"name": "steve"}`,
+		400, `{
+  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#constraint_failure",
+  "title": "The request would result in one or more Versions of \"/dirs/d1/files/f1\" not being compliant with its owning Group's \"equals\" constraint for attribute \"name\".",
+  "detail": "Versions: 1.",
+  "subject": "/dirs/d1/files/f1",
+  "args": {
+    "kind": "equals",
+    "path": "name"
+  },
+  "source": "d201b31810dc:registry:group:895"
+}
+`)
+
+	// Now f1 - good
+	XHTTP(t, reg, "PUT", "/dirs/d1/files/f1$details", `{"name": "joe"}`,
+		201, `{
+  "fileid": "f1",
+  "versionid": "1",
+  "self": "http://localhost:8181/dirs/d1/files/f1$details",
+  "xid": "/dirs/d1/files/f1",
+  "epoch": 1,
+  "name": "joe",
+  "isdefault": true,
+  "createdat": "2026-08-01T19:51:18.638764802Z",
+  "modifiedat": "2026-08-01T19:51:18.638764802Z",
+  "ancestorid": "1",
+
+  "metaurl": "http://localhost:8181/dirs/d1/files/f1/meta",
+  "versionsurl": "http://localhost:8181/dirs/d1/files/f1/versions",
+  "versionscount": 1
+}
+`)
+
+	// Now create another type of group, no name yet - dd1
+	XHTTP(t, reg, "PUT", "/datas/dd1", `{}`, 201, `{
+  "dataid": "dd1",
+  "self": "http://localhost:8181/datas/dd1",
+  "xid": "/datas/dd1",
+  "epoch": 1,
+  "createdat": "2026-08-01T19:54:56.641999897Z",
+  "modifiedat": "2026-08-01T19:54:56.641999897Z",
+
+  "filesurl": "http://localhost:8181/datas/dd1/files",
+  "filescount": 0
+}
+`)
+
+	// Create a resource fx
+	// Notice no groups constraint is run because dd1 has no 'name', even though
+	// d1 above does have its constraint run
+	XHTTP(t, reg, "PUT", "/datas/dd1/files/fx/meta",
+		`{"xref":"/dirs/d1/files/f1"}`, 201,
+		`{
+  "fileid": "fx",
+  "self": "http://localhost:8181/datas/dd1/files/fx/meta",
+  "xid": "/datas/dd1/files/fx/meta",
+  "xref": "/dirs/d1/files/f1",
+  "epoch": 1,
+  "createdat": "2026-08-01T19:56:29.950648612Z",
+  "modifiedat": "2026-08-01T19:56:29.950648612Z",
+  "readonly": false,
+
+  "defaultversionid": "1",
+  "defaultversionurl": "http://localhost:8181/datas/dd1/files/fx/versions/1$details",
+  "defaultversionsticky": false
+}
+`)
+
+	// Now give dd1 a "name", not 'joe'
+	XHTTP(t, reg, "PUT", "/datas/dd1", `{"name":"mary"}`, 400, `{
+  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#constraint_failure",
+  "title": "The request would result in one or more Versions of \"/datas/dd1/files/fx\" not being compliant with its owning Group's \"equals\" constraint for attribute \"name\".",
+  "detail": "Versions: 1.",
+  "subject": "/datas/dd1/files/fx",
+  "args": {
+    "kind": "equals",
+    "path": "name"
+  },
+  "source": "d201b31810dc:registry:group:895"
+}
+`)
+
+	// Now make it 'joe' - ok
+	XHTTP(t, reg, "PUT", "/datas/dd1", `{"name":"joe"}`, 200, `{
+  "dataid": "dd1",
+  "self": "http://localhost:8181/datas/dd1",
+  "xid": "/datas/dd1",
+  "epoch": 3,
+  "name": "joe",
+  "createdat": "2026-08-01T20:00:33.091971971Z",
+  "modifiedat": "2026-08-01T20:00:33.151265805Z",
+
+  "filesurl": "http://localhost:8181/datas/dd1/files",
+  "filescount": 1
+}
+`)
+
+	// Change dirs/d1 & ../files/f1's name to 'mary' which is ok for dirs/d1
+	// but not for data/dd1
+	XHTTP(t, reg, "PATCH", "/dirs/d1",
+		`{"name":"mary", "files": { "f1": { "name": "mary" }}}`, 400,
+		`{
+  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#constraint_failure",
+  "title": "The request would result in one or more Versions of \"/datas/dd1/files/fx\" not being compliant with its owning Group's \"equals\" constraint for attribute \"name\".",
+  "detail": "Versions: 1.",
+  "subject": "/datas/dd1/files/fx",
+  "args": {
+    "kind": "equals",
+    "path": "name"
+  },
+  "source": "d201b31810dc:registry:group:895"
+}
+`)
+
+	// force an enum issue for fx
+	XHTTP(t, reg, "PATCH", "/", `{
+    "dirs": {
+      "d1": {
+        "name": "mary",
+        "files": { "f1": { "name": "mary" } }
+      }
+    },
+    "datas": {
+      "dd1": { "name": "mary" }
+    }
+}`, 400, `{
+  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#constraint_failure",
+  "title": "The request would result in one or more Versions of \"/datas/dd1/files/fx\" not being compliant with its owning Group's \"enum\" constraint for attribute \"name\".",
+  "detail": "Versions: 1. Must be one of: joe.",
+  "subject": "/datas/dd1/files/fx",
+  "args": {
+    "kind": "enum",
+    "path": "name"
+  },
+  "source": "d201b31810dc:registry:group:969"
+}
+`)
+
 }

--- a/tests/model3_test.go
+++ b/tests/model3_test.go
@@ -3593,7 +3593,13 @@ func TestModelHasDocumentValidation(t *testing.T) {
 }
 `)
 
-	// Test 8: Create a resource with fileurl attribute, try to change to hasdocument=false - should FAIL
+	// Test 8: Create a resource with fileurl attribute (a reference, not
+	// actual document content), try to change to hasdocument=false. This
+	// should FAIL, but not because of hasdocument_violation - "fileurl" is
+	// only a reserved attribute name when hasdocument=true, so once the
+	// model changes to hasdocument=false the (undefined) "fileurl" simply
+	// becomes an unrecognized attribute like any other, and the generic
+	// attribute validator already correctly rejects it.
 	// First, clean up from previous tests
 	XHTTP(t, reg, "DELETE", "/dirs/d1", "", 204, "")
 	XHTTP(t, reg, "DELETE", "/dirs/d2", "", 204, "")
@@ -3674,14 +3680,42 @@ func TestModelHasDocumentValidation(t *testing.T) {
     }
   }
 }`, 400, `{
-  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#hasdocument_violation",
-  "title": "The request would cause Version \"/dirs/d3/files/f3/versions/1\" to be non-compliant. The Resource model has \"hasdocument\" set to \"false\" but this Version has document content.",
+  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#unknown_attribute",
+  "title": "An unknown attribute (fileurl) was specified for \"/dirs/d3/files/f3/versions/1\".",
   "subject": "/dirs/d3/files/f3/versions/1",
+  "args": {
+    "name": "fileurl"
+  },
   "source": "xxx"
 }
 `)
+	model := `{
+  "groups": {
+    "dirs": {
+      "singular": "dir",
+      "plural": "dirs",
+      "resources": {
+        "files": {
+          "singular": "file",
+          "plural": "files",
+          "hasdocument": false,
+          "attributes": {
+            "*": {
+              "type": "any"
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+	XHTTP(t, reg, "PUT", "/modelsource", model, 200, model+"\n")
 
-	// Test 9: Create a resource with fileproxyurl attribute, try to change to hasdocument=false - should FAIL
+	// Test 9: Create a resource with fileproxyurl attribute (a reference,
+	// not actual document content), try to change to hasdocument=false.
+	// Same reasoning as Test 8 - "fileproxyurl" is only reserved when
+	// hasdocument=true, so this becomes a plain unknown_attribute once
+	// hasdocument=false, not a hasdocument_violation.
 	// First, clean up from previous tests
 	XHTTP(t, reg, "DELETE", "/dirs/d3", "", 204, "")
 
@@ -3761,12 +3795,40 @@ func TestModelHasDocumentValidation(t *testing.T) {
     }
   }
 }`, 400, `{
-  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#hasdocument_violation",
-  "title": "The request would cause Version \"/dirs/d4/files/f4/versions/1\" to be non-compliant. The Resource model has \"hasdocument\" set to \"false\" but this Version has document content.",
+  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#unknown_attribute",
+  "title": "An unknown attribute (fileproxyurl) was specified for \"/dirs/d4/files/f4/versions/1\".",
   "subject": "/dirs/d4/files/f4/versions/1",
+  "args": {
+    "name": "fileproxyurl"
+  },
   "source": "xxx"
 }
 `)
+
+	model = `{
+  "groups": {
+    "dirs": {
+      "singular": "dir",
+      "plural": "dirs",
+      "resources": {
+        "files": {
+          "singular": "file",
+          "plural": "files",
+          "hasdocument": false,
+          "attributes": {
+            "*": {
+              "type": "any"
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+	// But when there's a "*" extension, then it's ok
+	XHTTP(t, reg, "PUT", "/modelsource", model, 200, model+"\n")
+
 }
 
 func TestModelStrictEnum(t *testing.T) {

--- a/tests/registry_test.go
+++ b/tests/registry_test.go
@@ -826,3 +826,139 @@ func TestRegistryRoot(t *testing.T) {
 `)
 
 }
+
+// Demonstrates a gap in Registry.VerifyData(): it never runs
+// Group.Validate() (the "equals"/"enum" cross-attribute constraint
+// checker) itself. VerifyData()'s resource loop marks each Resource's
+// owning Group via AddGroupToValidate() (inside ValidateResource()), but
+// VerifyData() never drains tx.GroupsToValidate - that only happens via
+// Registry.Validate(), which VerifyData() never calls. So a model change
+// that leaves EXISTING data non-compliant with a cross-attribute "equals"
+// group constraint is only caught "by accident", whenever something else
+// later happens to call Registry.Validate()/Tx.Validate() (e.g. HTTP's
+// SerializeQuery(), HTTPPUTModelSource()'s explicit drain, or
+// Tx.SaveAll()/SaveAllAndCommit()).
+//
+// "equals" is used (rather than "enum") because enum constraints get
+// merged into the attribute's own static validation rules (see
+// GetConstraints()), so ordinary per-Version attribute validation
+// independently (and coincidentally) catches enum violations, masking
+// this gap. "equals" is cross-entity/dynamic (compares to another live
+// Group attribute's current value) and can ONLY be caught by the
+// explicit Group.Validate() function.
+//
+// Exercises 3 variants of "how the model change reaches the server",
+// reusing the same Registry, resetting the data (DELETE /dirs) and
+// model (PUT /modelsource) back to the "v1" baseline between each one.
+func TestRegistryVerifyDataMissesGroupConstraintOnModelChange(t *testing.T) {
+	reg := NewRegistry("TestRegistryVerifyDataMissesGroupConstraintOnModelChange")
+	defer PassDeleteReg(t, reg)
+
+	modelSrc := `{
+      "groups": { "dirs": { "singular": "dir",
+        "attributes": {
+          "gstr": { "type": "string" },
+          "gstr2": { "type": "string" }
+        },
+        "constraints": { "files.mystr": { "equals": "gstr" } },
+        "resources": { "files": { "singular": "file",
+          "attributes": { "mystr": { "type": "string" } } } } } } }`
+
+	newModelSrc := `{
+      "groups": { "dirs": { "singular": "dir",
+        "attributes": {
+          "gstr": { "type": "string" },
+          "gstr2": { "type": "string" }
+        },
+        "constraints": { "files.mystr": { "equals": "gstr2" } },
+        "resources": { "files": { "singular": "file",
+          "attributes": { "mystr": { "type": "string" } } } } } } }`
+
+	// v1 model+data (via real HTTP, so it's fully committed): valid -
+	// f1.mystr ("foo") matches d1.gstr ("foo").
+	XHTTP(t, reg, "PUT", "/?inline=dirs.files", `{"modelsource":`+
+		modelSrc+`,
+      "dirs": { "d1": { "gstr": "foo", "gstr2": "bar",
+        "files": { "f1": { "mystr": "foo" } } } } }`,
+		200, `*`)
+
+	// Variant 1: pure Go API, no HTTP at all - Model.ApplyNewModelFromJSON()
+	// directly, with no subsequent SaveAllAndCommit()/Registry.Validate()
+	// call. This is the clearest, most direct reproduction: nothing else
+	// in this call chain happens to drain tx.GroupsToValidate.
+
+	// v2 model (pure Go API): retarget the constraint to gstr2.
+	// f1.mystr ("foo") no longer equals d1.gstr2 ("bar") - a genuine
+	// violation that ApplyNewModelFromJSON() should catch/reject.
+	xErr := reg.Model.ApplyNewModelFromJSON([]byte(newModelSrc), true)
+	XCheckErr(t, xErr, `{
+  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#constraint_failure",
+  "title": "The request would result in one or more Versions of \"/dirs/d1/files/f1\" not being compliant with its owning Group's \"equals\" constraint for attribute \"mystr\".",
+  "detail": "Versions: 1.",
+  "subject": "/dirs/d1/files/f1",
+  "args": {
+    "kind": "equals",
+    "path": "mystr"
+  },
+  "source": ":registry:group:895"
+}`)
+	reg.Rollback()
+
+	// Variant 2: single combined "PUT /" request containing BOTH the new
+	// modelsource AND (unrelated) data changes in the same body - the
+	// case the user specifically flagged: model needs to be applied
+	// (and, eventually, verified) but not before any new data in the
+	// same request has been loaded, since that new data may itself need
+	// to be checked too. Registry.Update() currently defers VerifyData()
+	// until after all incoming collections are upserted (see its
+	// "modelchanged" check) - this variant confirms whether that
+	// existing deferral correctly catches the violation once data
+	// loading is done.
+
+	// Single PUT / with the new modelsource AND an unrelated data
+	// change (a second, harmless Resource) in the same request body.
+	// f1 (untouched by this request) still violates the new
+	// constraint once gstr2 becomes the target.
+	XHTTP(t, reg, "PUT", "/?inline=dirs.files", `{"modelsource":`+
+		newModelSrc+`,
+      "dirs": { "d1": { "gstr": "foo", "gstr2": "bar",
+        "files": {
+          "f1": { "mystr": "foo" },
+          "f2": { "mystr": "bar" }
+        } } } }`,
+		400, `{
+  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#constraint_failure",
+  "title": "The request would result in one or more Versions of \"/dirs/d1/files/f1\" not being compliant with its owning Group's \"equals\" constraint for attribute \"mystr\".",
+  "detail": "Versions: 1.",
+  "subject": "/dirs/d1/files/f1",
+  "args": {
+    "kind": "equals",
+    "path": "mystr"
+  },
+  "source": ":registry:group:895"
+}
+`)
+
+	// Reset data+model back to the "v1" baseline for variant 3.
+	XHTTP(t, reg, "DELETE", "/dirs", ``, 204, ``)
+	XHTTP(t, reg, "PUT", "/?inline=dirs.files", `{"modelsource":`+
+		modelSrc+`,
+      "dirs": { "d1": { "gstr": "foo", "gstr2": "bar",
+        "files": { "f1": { "mystr": "foo" } } } } }`,
+		200, `*`)
+
+	// Variant 3: PUT /modelsource only (no data in the request body) -
+	// the endpoint dedicated to model-only updates.
+	XHTTP(t, reg, "PUT", "/modelsource", newModelSrc, 400, `{
+  "type": "https://github.com/xregistry/spec/blob/main/core/spec.md#constraint_failure",
+  "title": "The request would result in one or more Versions of \"/dirs/d1/files/f1\" not being compliant with its owning Group's \"equals\" constraint for attribute \"mystr\".",
+  "detail": "Versions: 1.",
+  "subject": "/dirs/d1/files/f1",
+  "args": {
+    "kind": "equals",
+    "path": "mystr"
+  },
+  "source": ":registry:group:895"
+}
+`)
+}

--- a/todo
+++ b/todo
@@ -121,3 +121,4 @@ TODOs:
 - look over the xref tests added for PR 19
 - clean-up design of model save/apply 
 - add support for json structure
+- when turning off hasdoc, convert "file" to "filebase64" as an extension


### PR DESCRIPTION
enable group constraints across xrefs and more tests

get rid of premature resource.ValidateResource calls

left over from the big (remove views) PR