### PR TITLE
Fix: error while updating attributes for resources

### DIFF
--- a/cmds/xr/create.go
+++ b/cmds/xr/create.go
@@ -188,10 +188,10 @@ func createFunc(cmd *cobra.Command, args []string) {
 			Error(xErr)
 			if rm.GetHasDocument() && !isMetadata && len(data) > 0 {
 				doc_data = true
-				ops = append(ops, Operation{
+				ops = append([]Operation{{
 					Action: "set",
 					Value:  rm.Singular + "base64=" + base64.StdEncoding.EncodeToString([]byte(data)),
-				})
+				}}, ops...)
 			}
 		}
 

--- a/cmds/xr/create.go
+++ b/cmds/xr/create.go
@@ -185,7 +185,7 @@ func createFunc(cmd *cobra.Command, args []string) {
 		if xid.Type == ENTITY_RESOURCE || xid.Type == ENTITY_VERSION {
 			rm, xErr := xrlib.GetResourceModelFrom(xid, reg)
 			Error(xErr)
-			if rm.GetHasDocument() && !isMetadata {
+			if rm.GetHasDocument() && !isMetadata && len(data) > 0 {
 				doc_data = true
 				ops = append(ops, Operation{
 					Action: "set",

--- a/cmds/xr/create.go
+++ b/cmds/xr/create.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -189,7 +190,7 @@ func createFunc(cmd *cobra.Command, args []string) {
 				doc_data = true
 				ops = append(ops, Operation{
 					Action: "set",
-					Value:  "file=" + data,
+					Value:  rm.Singular + "base64=" + base64.StdEncoding.EncodeToString([]byte(data)),
 				})
 			}
 		}

--- a/cmds/xr/create.go
+++ b/cmds/xr/create.go
@@ -168,17 +168,35 @@ func createFunc(cmd *cobra.Command, args []string) {
 	}
 
 	if cmd.Flags().Changed("set") || cmd.Flags().Changed("del") {
-		isMetadata = true
 		dataMap := map[string]any{}
 
 		ops := GetArgOrder(cmd, os.Args)
 
-		oldData, xErr := reg.DownloadObject(xid.String())
+		Objectpath := xid.String()
+		if xid.Type == ENTITY_RESOURCE || xid.Type == ENTITY_VERSION {
+			Objectpath += "$details"
+		}
+		oldData, xErr := reg.DownloadObject(Objectpath)
 		if !xErr.IsType("not_found") {
 			Error(xErr)
 		}
 
-		if len(data) > 0 {
+		doc_data := false
+		if xid.Type == ENTITY_RESOURCE || xid.Type == ENTITY_VERSION {
+			rm, xErr := xrlib.GetResourceModelFrom(xid, reg)
+			Error(xErr)
+			if rm.GetHasDocument() && !isMetadata {
+				doc_data = true
+				ops = append(ops, Operation{
+					Action: "set",
+					Value:  "file=" + data,
+				})
+			}
+		}
+
+		isMetadata = true
+
+		if len(data) > 0 && !doc_data {
 			// We don't really care if it's not valid json from a CLI
 			// perspective unless they're going to del/set something.
 			// That's why we don't do this outside of this if-changed block

--- a/cmds/xr/create.go
+++ b/cmds/xr/create.go
@@ -166,17 +166,35 @@ func createFunc(cmd *cobra.Command, args []string) {
 	}
 
 	if cmd.Flags().Changed("set") || cmd.Flags().Changed("del") {
-		isMetadata = true
 		dataMap := map[string]any{}
 
 		ops := GetArgOrder(cmd, os.Args)
 
-		oldData, xErr := reg.DownloadObject(xid.String())
+		Objectpath := xid.String()
+		if xid.Type == ENTITY_RESOURCE || xid.Type == ENTITY_VERSION {
+			Objectpath += "$details"
+		}
+		oldData, xErr := reg.DownloadObject(Objectpath)
 		if !xErr.IsType("not_found") {
 			Error(xErr)
 		}
 
-		if len(data) > 0 {
+		doc_data := false
+		if xid.Type == ENTITY_RESOURCE || xid.Type == ENTITY_VERSION {
+			rm, xErr := xrlib.GetResourceModelFrom(xid, reg)
+			Error(xErr)
+			if rm.GetHasDocument() && !isMetadata {
+				doc_data = true
+				ops = append(ops, Operation{
+					Action: "set",
+					Value:  "file=" + data,
+				})
+			}
+		}
+
+		isMetadata = true
+
+		if len(data) > 0 && !doc_data {
 			// We don't really care if it's not valid json from a CLI
 			// perspective unless they're going to del/set something.
 			// That's why we don't do this outside of this if-changed block

--- a/cmds/xr/create.go
+++ b/cmds/xr/create.go
@@ -183,7 +183,7 @@ func createFunc(cmd *cobra.Command, args []string) {
 		if xid.Type == ENTITY_RESOURCE || xid.Type == ENTITY_VERSION {
 			rm, xErr := xrlib.GetResourceModelFrom(xid, reg)
 			Error(xErr)
-			if rm.GetHasDocument() && !isMetadata {
+			if rm.GetHasDocument() && !isMetadata && len(data) > 0 {
 				doc_data = true
 				ops = append(ops, Operation{
 					Action: "set",

--- a/tests/xr_test.go
+++ b/tests/xr_test.go
@@ -2019,6 +2019,155 @@ func TestXRResourceType(t *testing.T) {
 		"", "Created Resource type: fs22\n", true)
 }
 
+func TestXRResourceFlags(t *testing.T) {
+	reg := NewRegistry("TestXRResourceFlags")
+	defer PassDeleteReg(t, reg)
+
+	XCLIServer("localhost:8181")
+
+	XCLI(t, "model resource create files:file -g dirs:dir --has-doc", "", "", "", true)
+	XCLI(t, "model resource create datas:data -g dirs --no-has-doc", "", "", "", true)
+
+	// Test --set during create
+	XCLI(t, "create /dirs/d1/files/f1 --set name=file1", "", "", "", true)
+	XCLI(t, "get /dirs/d1/files/f1 -m", "", `{
+  "fileid": "f1",
+  "versionid": "1",
+  "self": "http://localhost:8181/dirs/d1/files/f1$details",
+  "xid": "/dirs/d1/files/f1",
+  "epoch": 1,
+  "name": "file1",
+  "isdefault": true,
+  "createdat": "YYYY-MM-DDTHH:MM:01Z",
+  "modifiedat": "YYYY-MM-DDTHH:MM:01Z",
+  "ancestorid": "1",
+  "contenttype": "application/json",
+  "metaurl": "http://localhost:8181/dirs/d1/files/f1/meta",
+  "versionsurl": "http://localhost:8181/dirs/d1/files/f1/versions",
+  "versionscount": 1
+}
+`, "", true)
+
+	XCLI(t, "create /dirs/d1/datas/d1 --set name=data1", "", "", "", true)
+	XCLI(t, "get /dirs/d1/datas/d1", "", `{
+  "dataid": "d1",
+  "versionid": "1",
+  "self": "http://localhost:8181/dirs/d1/datas/d1",
+  "xid": "/dirs/d1/datas/d1",
+  "epoch": 1,
+  "name": "data1",
+  "isdefault": true,
+  "createdat": "YYYY-MM-DDTHH:MM:01Z",
+  "modifiedat": "YYYY-MM-DDTHH:MM:01Z",
+  "ancestorid": "1",
+  "metaurl": "http://localhost:8181/dirs/d1/datas/d1/meta",
+  "versionsurl": "http://localhost:8181/dirs/d1/datas/d1/versions",
+  "versionscount": 1
+}
+`, "", true)
+
+	// Test --set during update
+	XCLI(t, "update /dirs/d1/files/f1 --set name=file2", "", "", "", true)
+	XCLI(t, "get /dirs/d1/files/f1 -m", "", `{
+  "fileid": "f1",
+  "versionid": "1",
+  "self": "http://localhost:8181/dirs/d1/files/f1$details",
+  "xid": "/dirs/d1/files/f1",
+  "epoch": 2,
+  "name": "file2",
+  "isdefault": true,
+  "createdat": "YYYY-MM-DDTHH:MM:01Z",
+  "modifiedat": "YYYY-MM-DDTHH:MM:02Z",
+  "ancestorid": "1",
+  "contenttype": "application/json",
+  "metaurl": "http://localhost:8181/dirs/d1/files/f1/meta",
+  "versionsurl": "http://localhost:8181/dirs/d1/files/f1/versions",
+  "versionscount": 1
+}
+`, "", true)
+
+	XCLI(t, "update /dirs/d1/datas/d1 --set name=data2", "", "", "", true)
+	XCLI(t, "get /dirs/d1/datas/d1", "", `{
+  "dataid": "d1",
+  "versionid": "1",
+  "self": "http://localhost:8181/dirs/d1/datas/d1",
+  "xid": "/dirs/d1/datas/d1",
+  "epoch": 2,
+  "name": "data2",
+  "isdefault": true,
+  "createdat": "YYYY-MM-DDTHH:MM:01Z",
+  "modifiedat": "YYYY-MM-DDTHH:MM:02Z",
+  "ancestorid": "1",
+  "metaurl": "http://localhost:8181/dirs/d1/datas/d1/meta",
+  "versionsurl": "http://localhost:8181/dirs/d1/datas/d1/versions",
+  "versionscount": 1
+}
+`, "", true)
+
+	// Test --set with -d on resource with document
+	XCLI(t, `update /dirs/d1/files/f1 -d '{"name":"file3"}' --set name=file4`, "", "", "", true)
+	XCLI(t, "get /dirs/d1/files/f1", "", `{"name":"file3"}`, "", true)
+	XCLI(t, "get /dirs/d1/files/f1 -m", "", `{
+  "fileid": "f1",
+  "versionid": "1",
+  "self": "http://localhost:8181/dirs/d1/files/f1$details",
+  "xid": "/dirs/d1/files/f1",
+  "epoch": 3,
+  "name": "file4",
+  "isdefault": true,
+  "createdat": "YYYY-MM-DDTHH:MM:01Z",
+  "modifiedat": "YYYY-MM-DDTHH:MM:02Z",
+  "ancestorid": "1",
+  "contenttype": "application/json",
+  "metaurl": "http://localhost:8181/dirs/d1/files/f1/meta",
+  "versionsurl": "http://localhost:8181/dirs/d1/files/f1/versions",
+  "versionscount": 1
+}
+`, "", true)
+
+	// Test --set with -d on resource without document
+	XCLI(t, `update /dirs/d1/datas/d1 -d '{"name":"data3","description":"data3"}' --set name=data4`, "", "", "", true)
+	XCLI(t, "get /dirs/d1/datas/d1", "", `{
+  "dataid": "d1",
+  "versionid": "1",
+  "self": "http://localhost:8181/dirs/d1/datas/d1",
+  "xid": "/dirs/d1/datas/d1",
+  "epoch": 3,
+  "name": "data4",
+  "isdefault": true,
+  "description": "data3",
+  "createdat": "YYYY-MM-DDTHH:MM:01Z",
+  "modifiedat": "YYYY-MM-DDTHH:MM:02Z",
+  "ancestorid": "1",
+  "metaurl": "http://localhost:8181/dirs/d1/datas/d1/meta",
+  "versionsurl": "http://localhost:8181/dirs/d1/datas/d1/versions",
+  "versionscount": 1
+}
+`, "", true)
+
+	// Test --set with -d and -m on resource with document
+	XCLI(t, `update /dirs/d1/files/f1 -m -d '{"description":"file5"}' --set name=file5`, "", "", "", true)
+	XCLI(t, "get /dirs/d1/files/f1", "", `{"name":"file3"}`, "", true)
+	XCLI(t, "get /dirs/d1/files/f1 -m", "", `{
+  "fileid": "f1",
+  "versionid": "1",
+  "self": "http://localhost:8181/dirs/d1/files/f1$details",
+  "xid": "/dirs/d1/files/f1",
+  "epoch": 4,
+  "name": "file5",
+  "isdefault": true,
+  "description": "file5",
+  "createdat": "YYYY-MM-DDTHH:MM:01Z",
+  "modifiedat": "YYYY-MM-DDTHH:MM:02Z",
+  "ancestorid": "1",
+  "contenttype": "application/json",
+  "metaurl": "http://localhost:8181/dirs/d1/files/f1/meta",
+  "versionsurl": "http://localhost:8181/dirs/d1/files/f1/versions",
+  "versionscount": 1
+}
+`, "", true)
+}
+
 func TestXRConfig(t *testing.T) {
 	reg := NewRegistry("TestXRConfig")
 	defer PassDeleteReg(t, reg)

--- a/tests/xr_test.go
+++ b/tests/xr_test.go
@@ -2031,7 +2031,6 @@ func TestXRResourceFlags(t *testing.T) {
   "createdat": "YYYY-MM-DDTHH:MM:01Z",
   "modifiedat": "YYYY-MM-DDTHH:MM:01Z",
   "ancestorid": "1",
-  "contenttype": "application/json",
   "metaurl": "http://localhost:8181/dirs/d1/files/f1/meta",
   "versionsurl": "http://localhost:8181/dirs/d1/files/f1/versions",
   "versionscount": 1
@@ -2069,7 +2068,6 @@ func TestXRResourceFlags(t *testing.T) {
   "createdat": "YYYY-MM-DDTHH:MM:01Z",
   "modifiedat": "YYYY-MM-DDTHH:MM:02Z",
   "ancestorid": "1",
-  "contenttype": "application/json",
   "metaurl": "http://localhost:8181/dirs/d1/files/f1/meta",
   "versionsurl": "http://localhost:8181/dirs/d1/files/f1/versions",
   "versionscount": 1
@@ -2095,8 +2093,8 @@ func TestXRResourceFlags(t *testing.T) {
 `, "", true)
 
 	// Test --set with -d on resource with document
-	XCLI(t, `update /dirs/d1/files/f1 -d '{"name":"file3"}' --set name=file4`, "", "", "", true)
-	XCLI(t, "get /dirs/d1/files/f1", "", `{"name":"file3"}`, "", true)
+	XCLI(t, "update /dirs/d1/files/f1 -d 'hello world' --set name=file4", "", "", "", true)
+	XCLI(t, "get /dirs/d1/files/f1", "", "hello world", "", true)
 	XCLI(t, "get /dirs/d1/files/f1 -m", "", `{
   "fileid": "f1",
   "versionid": "1",
@@ -2108,7 +2106,6 @@ func TestXRResourceFlags(t *testing.T) {
   "createdat": "YYYY-MM-DDTHH:MM:01Z",
   "modifiedat": "YYYY-MM-DDTHH:MM:02Z",
   "ancestorid": "1",
-  "contenttype": "application/json",
   "metaurl": "http://localhost:8181/dirs/d1/files/f1/meta",
   "versionsurl": "http://localhost:8181/dirs/d1/files/f1/versions",
   "versionscount": 1
@@ -2136,8 +2133,8 @@ func TestXRResourceFlags(t *testing.T) {
 `, "", true)
 
 	// Test --set with -d and -m on resource with document
-	XCLI(t, `update /dirs/d1/files/f1 -m -d '{"description":"file5"}' --set name=file5`, "", "", "", true)
-	XCLI(t, "get /dirs/d1/files/f1", "", `{"name":"file3"}`, "", true)
+	XCLI(t, `update /dirs/d1/files/f1 -m --set name=file5 -d '{"name":"file6","description":"file5"}'`, "", "", "", true)
+	XCLI(t, "get /dirs/d1/files/f1", "", "hello world", "", true)
 	XCLI(t, "get /dirs/d1/files/f1 -m", "", `{
   "fileid": "f1",
   "versionid": "1",
@@ -2150,7 +2147,6 @@ func TestXRResourceFlags(t *testing.T) {
   "createdat": "YYYY-MM-DDTHH:MM:01Z",
   "modifiedat": "YYYY-MM-DDTHH:MM:02Z",
   "ancestorid": "1",
-  "contenttype": "application/json",
   "metaurl": "http://localhost:8181/dirs/d1/files/f1/meta",
   "versionsurl": "http://localhost:8181/dirs/d1/files/f1/versions",
   "versionscount": 1

--- a/tests/xr_test.go
+++ b/tests/xr_test.go
@@ -2009,6 +2009,155 @@ func TestXRResourceType(t *testing.T) {
 		"", "Created Resource type: fs22\n", true)
 }
 
+func TestXRResourceFlags(t *testing.T) {
+	reg := NewRegistry("TestXRResourceFlags")
+	defer PassDeleteReg(t, reg)
+
+	XCLIServer("localhost:8181")
+
+	XCLI(t, "model resource create files:file -g dirs:dir --has-doc", "", "", "", true)
+	XCLI(t, "model resource create datas:data -g dirs --no-has-doc", "", "", "", true)
+
+	// Test --set during create
+	XCLI(t, "create /dirs/d1/files/f1 --set name=file1", "", "", "", true)
+	XCLI(t, "get /dirs/d1/files/f1 -m", "", `{
+  "fileid": "f1",
+  "versionid": "1",
+  "self": "http://localhost:8181/dirs/d1/files/f1$details",
+  "xid": "/dirs/d1/files/f1",
+  "epoch": 1,
+  "name": "file1",
+  "isdefault": true,
+  "createdat": "YYYY-MM-DDTHH:MM:01Z",
+  "modifiedat": "YYYY-MM-DDTHH:MM:01Z",
+  "ancestorid": "1",
+  "contenttype": "application/json",
+  "metaurl": "http://localhost:8181/dirs/d1/files/f1/meta",
+  "versionsurl": "http://localhost:8181/dirs/d1/files/f1/versions",
+  "versionscount": 1
+}
+`, "", true)
+
+	XCLI(t, "create /dirs/d1/datas/d1 --set name=data1", "", "", "", true)
+	XCLI(t, "get /dirs/d1/datas/d1", "", `{
+  "dataid": "d1",
+  "versionid": "1",
+  "self": "http://localhost:8181/dirs/d1/datas/d1",
+  "xid": "/dirs/d1/datas/d1",
+  "epoch": 1,
+  "name": "data1",
+  "isdefault": true,
+  "createdat": "YYYY-MM-DDTHH:MM:01Z",
+  "modifiedat": "YYYY-MM-DDTHH:MM:01Z",
+  "ancestorid": "1",
+  "metaurl": "http://localhost:8181/dirs/d1/datas/d1/meta",
+  "versionsurl": "http://localhost:8181/dirs/d1/datas/d1/versions",
+  "versionscount": 1
+}
+`, "", true)
+
+	// Test --set during update
+	XCLI(t, "update /dirs/d1/files/f1 --set name=file2", "", "", "", true)
+	XCLI(t, "get /dirs/d1/files/f1 -m", "", `{
+  "fileid": "f1",
+  "versionid": "1",
+  "self": "http://localhost:8181/dirs/d1/files/f1$details",
+  "xid": "/dirs/d1/files/f1",
+  "epoch": 2,
+  "name": "file2",
+  "isdefault": true,
+  "createdat": "YYYY-MM-DDTHH:MM:01Z",
+  "modifiedat": "YYYY-MM-DDTHH:MM:02Z",
+  "ancestorid": "1",
+  "contenttype": "application/json",
+  "metaurl": "http://localhost:8181/dirs/d1/files/f1/meta",
+  "versionsurl": "http://localhost:8181/dirs/d1/files/f1/versions",
+  "versionscount": 1
+}
+`, "", true)
+
+	XCLI(t, "update /dirs/d1/datas/d1 --set name=data2", "", "", "", true)
+	XCLI(t, "get /dirs/d1/datas/d1", "", `{
+  "dataid": "d1",
+  "versionid": "1",
+  "self": "http://localhost:8181/dirs/d1/datas/d1",
+  "xid": "/dirs/d1/datas/d1",
+  "epoch": 2,
+  "name": "data2",
+  "isdefault": true,
+  "createdat": "YYYY-MM-DDTHH:MM:01Z",
+  "modifiedat": "YYYY-MM-DDTHH:MM:02Z",
+  "ancestorid": "1",
+  "metaurl": "http://localhost:8181/dirs/d1/datas/d1/meta",
+  "versionsurl": "http://localhost:8181/dirs/d1/datas/d1/versions",
+  "versionscount": 1
+}
+`, "", true)
+
+	// Test --set with -d on resource with document
+	XCLI(t, `update /dirs/d1/files/f1 -d '{"name":"file3"}' --set name=file4`, "", "", "", true)
+	XCLI(t, "get /dirs/d1/files/f1", "", `{"name":"file3"}`, "", true)
+	XCLI(t, "get /dirs/d1/files/f1 -m", "", `{
+  "fileid": "f1",
+  "versionid": "1",
+  "self": "http://localhost:8181/dirs/d1/files/f1$details",
+  "xid": "/dirs/d1/files/f1",
+  "epoch": 3,
+  "name": "file4",
+  "isdefault": true,
+  "createdat": "YYYY-MM-DDTHH:MM:01Z",
+  "modifiedat": "YYYY-MM-DDTHH:MM:02Z",
+  "ancestorid": "1",
+  "contenttype": "application/json",
+  "metaurl": "http://localhost:8181/dirs/d1/files/f1/meta",
+  "versionsurl": "http://localhost:8181/dirs/d1/files/f1/versions",
+  "versionscount": 1
+}
+`, "", true)
+
+	// Test --set with -d on resource without document
+	XCLI(t, `update /dirs/d1/datas/d1 -d '{"name":"data3","description":"data3"}' --set name=data4`, "", "", "", true)
+	XCLI(t, "get /dirs/d1/datas/d1", "", `{
+  "dataid": "d1",
+  "versionid": "1",
+  "self": "http://localhost:8181/dirs/d1/datas/d1",
+  "xid": "/dirs/d1/datas/d1",
+  "epoch": 3,
+  "name": "data4",
+  "isdefault": true,
+  "description": "data3",
+  "createdat": "YYYY-MM-DDTHH:MM:01Z",
+  "modifiedat": "YYYY-MM-DDTHH:MM:02Z",
+  "ancestorid": "1",
+  "metaurl": "http://localhost:8181/dirs/d1/datas/d1/meta",
+  "versionsurl": "http://localhost:8181/dirs/d1/datas/d1/versions",
+  "versionscount": 1
+}
+`, "", true)
+
+	// Test --set with -d and -m on resource with document
+	XCLI(t, `update /dirs/d1/files/f1 -m -d '{"description":"file5"}' --set name=file5`, "", "", "", true)
+	XCLI(t, "get /dirs/d1/files/f1", "", `{"name":"file3"}`, "", true)
+	XCLI(t, "get /dirs/d1/files/f1 -m", "", `{
+  "fileid": "f1",
+  "versionid": "1",
+  "self": "http://localhost:8181/dirs/d1/files/f1$details",
+  "xid": "/dirs/d1/files/f1",
+  "epoch": 4,
+  "name": "file5",
+  "isdefault": true,
+  "description": "file5",
+  "createdat": "YYYY-MM-DDTHH:MM:01Z",
+  "modifiedat": "YYYY-MM-DDTHH:MM:02Z",
+  "ancestorid": "1",
+  "contenttype": "application/json",
+  "metaurl": "http://localhost:8181/dirs/d1/files/f1/meta",
+  "versionsurl": "http://localhost:8181/dirs/d1/files/f1/versions",
+  "versionscount": 1
+}
+`, "", true)
+}
+
 func TestXRConfig(t *testing.T) {
 	reg := NewRegistry("TestXRConfig")
 	defer PassDeleteReg(t, reg)

--- a/tests/xr_test.go
+++ b/tests/xr_test.go
@@ -2152,6 +2152,30 @@ func TestXRResourceFlags(t *testing.T) {
   "versionscount": 1
 }
 `, "", true)
+
+	// Test -d is processed before --set on resource without document
+	XCLI(t, `update /dirs/d1/datas/d1 --set name=data5 -d '{"name":"data6","description":"data7"}'`, "", "", "", true)
+	XCLI(t, "get /dirs/d1/datas/d1", "", `{
+  "dataid": "d1",
+  "versionid": "1",
+  "self": "http://localhost:8181/dirs/d1/datas/d1",
+  "xid": "/dirs/d1/datas/d1",
+  "epoch": 4,
+  "name": "data5",
+  "isdefault": true,
+  "description": "data7",
+  "createdat": "YYYY-MM-DDTHH:MM:01Z",
+  "modifiedat": "YYYY-MM-DDTHH:MM:02Z",
+  "ancestorid": "1",
+  "metaurl": "http://localhost:8181/dirs/d1/datas/d1/meta",
+  "versionsurl": "http://localhost:8181/dirs/d1/datas/d1/versions",
+  "versionscount": 1
+}
+`, "", true)
+
+	// Test -d is processed before --set on resource with document
+	XCLI(t, "update /dirs/d1/files/f1 -d 'hello world2' --set filebase64=aGVsbG8gd29ybGQz", "", "", "", true)
+	XCLI(t, "get /dirs/d1/files/f1", "", "hello world3", "", true)
 }
 
 func TestXRConfig(t *testing.T) {


### PR DESCRIPTION
### Before
When using set or del flag for resource the embedded content was getting passed to the `json.Unmarshal` which gave 
`There was an error parsing the response from the server (http://localhost:8080/dirs/yourdocs/files/cv): unexpected end of JSON input. Response: .`

### After
Now for resource object the xid+`$details`  will be given as parameter to reg.DownloadObject so as to get all the xRegistry Data.